### PR TITLE
Qualify Error redirect with its controller

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QualificationDetailsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QualificationDetailsController.cs
@@ -27,16 +27,23 @@ public class QualificationDetailsController : Controller
     [HttpGet("qualification-details/{qualificationId}")]
     public async Task<IActionResult> Index(string qualificationId)
     {
-        if (string.IsNullOrEmpty(qualificationId)) return BadRequest();
+        if (string.IsNullOrEmpty(qualificationId))
+        {
+            return BadRequest();
+        }
 
         var detailsPageContent = await _contentService.GetDetailsPage();
-        if (detailsPageContent is null) return RedirectToAction("Error");
+        if (detailsPageContent is null)
+        {
+            return RedirectToAction("Error", "Home");
+        }
 
         var qualification = await _contentService.GetQualificationById(qualificationId);
         if (qualification is null)
         {
             return RedirectToAction("Error", "Home");
         }
+
         var model = Map(qualification);
         model.Content = detailsPageContent;
         return View(model);
@@ -44,7 +51,7 @@ public class QualificationDetailsController : Controller
 
     private QualificationDetailsModel Map(Qualification qualification)
     {
-        return new QualificationDetailsModel()
+        return new QualificationDetailsModel
         {
             QualificationId = qualification.QualificationId,
             QualificationLevel = qualification.QualificationLevel,


### PR DESCRIPTION
Also: consistency of return block format.
NB: we should address at some point that `_logger` isn't ever used (...I have the benefit of ReSharper!)

# Description

Null `detailsPageContent` was redirecting to unqualified (and therefore erroneous) controller method.

## Ticket number (if applicable)

# How Has This Been Tested?

Runs locally, & error page appears if `detailsPageContent` is `null`.

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules