### PR TITLE
Use FluentAssertions

### DIFF
--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/AdviceControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/AdviceControllerTests.cs
@@ -3,6 +3,7 @@ using Dfe.EarlyYearsQualification.Content.Entities;
 using Dfe.EarlyYearsQualification.Content.Services;
 using Dfe.EarlyYearsQualification.Web.Controllers;
 using Dfe.EarlyYearsQualification.Web.Models.Content;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,10 +14,9 @@ namespace Dfe.EarlyYearsQualification.UnitTests.Controllers;
 [TestClass]
 public class AdviceControllerTests
 {
-
     private readonly ILogger<AdviceController> _mockLogger = new NullLoggerFactory().CreateLogger<AdviceController>();
-    private Mock<IContentService> _mockContentService = new();
     private AdviceController? _controller;
+    private Mock<IContentService> _mockContentService = new();
 
     [TestInitialize]
     public void BeforeEachTest()
@@ -28,30 +28,39 @@ public class AdviceControllerTests
     [TestMethod]
     public async Task QualificationOutsideTheUnitedKingdom_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
     {
-        _mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedOutsideTheUk)).ReturnsAsync((AdvicePage)default!).Verifiable();
+        _mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedOutsideTheUk))
+                           .ReturnsAsync((AdvicePage)default!).Verifiable();
         var result = await _controller!.QualificationOutsideTheUnitedKingdom();
 
         _mockContentService.VerifyAll();
-        Assert.IsNotNull(result);
+
+        result.Should().NotBeNull();
+
         var resultType = result as RedirectToActionResult;
-        Assert.IsNotNull(resultType);
-        Assert.AreEqual("Error", resultType.ActionName);
-        Assert.AreEqual("Home", resultType.ControllerName);
+
+        resultType.Should().NotBeNull();
+
+        resultType!.ActionName.Should().Be("Error");
+        resultType.ControllerName.Should().Be("Home");
     }
 
     [TestMethod]
     public async Task QualificationOutsideTheUnitedKingdom_ContentServiceReturnsAdvicePage_ReturnsAdvicePageModel()
     {
         var advicePage = new AdvicePage { Heading = "Heading", BodyHtml = "Test html body" };
-        _mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedOutsideTheUk)).ReturnsAsync(advicePage);
+        _mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedOutsideTheUk))
+                           .ReturnsAsync(advicePage);
         var result = await _controller!.QualificationOutsideTheUnitedKingdom();
 
-        Assert.IsNotNull(result);
+        result.Should().NotBeNull();
+
         var resultType = result as ViewResult;
-        Assert.IsNotNull(resultType);
-        var model = resultType.Model as AdvicePageModel;
-        Assert.IsNotNull(model);
-        Assert.AreEqual(advicePage.Heading, model.Heading);
-        Assert.AreEqual(advicePage.BodyHtml, model.BodyContent);
+        resultType.Should().NotBeNull();
+
+        var model = resultType!.Model as AdvicePageModel;
+        model.Should().NotBeNull();
+
+        model!.Heading.Should().Be(advicePage.Heading);
+        model.BodyContent.Should().Be(advicePage.BodyHtml);
     }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/HealthControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/HealthControllerTests.cs
@@ -1,4 +1,5 @@
 using Dfe.EarlyYearsQualification.Web.Controllers;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.EarlyYearsQualification.UnitTests.Controllers;
@@ -11,8 +12,8 @@ public class HealthControllerTests
     {
         var controller = new HealthController();
         var result = controller.Get();
-        
-        Assert.IsNotNull(result);
-        Assert.IsInstanceOfType<OkResult>(result);
+
+        result.Should().NotBeNull();
+        result.Should().BeOfType<OkResult>();
     }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/HomeControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/HomeControllerTests.cs
@@ -2,6 +2,7 @@ using Dfe.EarlyYearsQualification.Content.Entities;
 using Dfe.EarlyYearsQualification.Content.Services;
 using Dfe.EarlyYearsQualification.Web.Controllers;
 using Dfe.EarlyYearsQualification.Web.Models.Content;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,8 +14,8 @@ namespace Dfe.EarlyYearsQualification.UnitTests.Controllers;
 public class HomeControllerTests
 {
     private readonly ILogger<HomeController> _mockLogger = new NullLoggerFactory().CreateLogger<HomeController>();
-    private Mock<IContentService> _mockContentService = new();
     private HomeController? _controller;
+    private Mock<IContentService> _mockContentService = new();
 
     [TestInitialize]
     public void BeforeEachTest()
@@ -29,38 +30,41 @@ public class HomeControllerTests
         _mockContentService.Setup(x => x.GetStartPage()).ReturnsAsync((StartPage)default!);
         var result = await _controller!.Index();
 
-        Assert.IsNotNull(result);
+        result.Should().NotBeNull();
+
         var resultType = result as RedirectToActionResult;
-        Assert.IsNotNull(resultType);
-        Assert.AreEqual("Error", resultType.ActionName);
+        resultType.Should().NotBeNull();
+        resultType!.ActionName.Should().Be("Error");
     }
 
     [TestMethod]
     public async Task Index_ContentServiceReturnsContent_ReturnsStartPageModel()
     {
         var startPageResult = new StartPage
-        {
-            CtaButtonText = "Start now",
-            Header = "This is the header",
-            PostCtaButtonContentHtml = "This is the post cta content",
-            PreCtaButtonContentHtml = "This is the pre cta content",
-            RightHandSideContentHeader = "This is the side content header",
-            RightHandSideContentHtml = "This is the side content"
-        };
+                              {
+                                  CtaButtonText = "Start now",
+                                  Header = "This is the header",
+                                  PostCtaButtonContentHtml = "This is the post cta content",
+                                  PreCtaButtonContentHtml = "This is the pre cta content",
+                                  RightHandSideContentHeader = "This is the side content header",
+                                  RightHandSideContentHtml = "This is the side content"
+                              };
 
         _mockContentService.Setup(x => x.GetStartPage()).ReturnsAsync(startPageResult);
         var result = await _controller!.Index();
 
-        Assert.IsNotNull(result);
+        result.Should().NotBeNull();
+
         var resultType = result as ViewResult;
-        Assert.IsNotNull(resultType);
-        var model = resultType.Model as StartPageModel;
-        Assert.IsNotNull(model);
-        Assert.AreEqual(startPageResult.Header, model.Header);
-        Assert.AreEqual(startPageResult.CtaButtonText, model.CtaButtonText);
-        Assert.AreEqual(startPageResult.PostCtaButtonContentHtml, model.PostCtaButtonContent);
-        Assert.AreEqual(startPageResult.PreCtaButtonContentHtml, model.PreCtaButtonContent);
-        Assert.AreEqual(startPageResult.RightHandSideContentHtml, model.RightHandSideContent);
-        Assert.AreEqual(startPageResult.RightHandSideContentHeader, model.RightHandSideContentHeader);
+        resultType.Should().NotBeNull();
+
+        var model = resultType!.Model as StartPageModel;
+        model.Should().NotBeNull();
+        model!.Header.Should().Be(startPageResult.Header);
+        model.CtaButtonText.Should().Be(startPageResult.CtaButtonText);
+        model.PostCtaButtonContent.Should().Be(startPageResult.PostCtaButtonContentHtml);
+        model.PreCtaButtonContent.Should().Be(startPageResult.PreCtaButtonContentHtml);
+        model.RightHandSideContent.Should().Be(startPageResult.RightHandSideContentHtml);
+        model.RightHandSideContentHeader.Should().Be(startPageResult.RightHandSideContentHeader);
     }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QualificationDetailsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QualificationDetailsControllerTests.cs
@@ -2,6 +2,7 @@ using Dfe.EarlyYearsQualification.Content.Entities;
 using Dfe.EarlyYearsQualification.Content.Services;
 using Dfe.EarlyYearsQualification.Web.Controllers;
 using Dfe.EarlyYearsQualification.Web.Models.Content;
+using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -13,22 +14,23 @@ namespace Dfe.EarlyYearsQualification.UnitTests.Controllers;
 [TestClass]
 public class QualificationDetailsControllerTests
 {
+    private readonly ILogger<QualificationDetailsController> _mockLogger =
+        new NullLoggerFactory().CreateLogger<QualificationDetailsController>();
 
-    private readonly ILogger<QualificationDetailsController> _mockLogger = new NullLoggerFactory().CreateLogger<QualificationDetailsController>();
-    private Mock<IContentService> _mockContentService = new();
     private QualificationDetailsController? _controller;
+    private Mock<IContentService> _mockContentService = new();
 
     [TestInitialize]
     public void BeforeEachTest()
     {
         _mockContentService = new Mock<IContentService>();
         _controller = new QualificationDetailsController(_mockLogger, _mockContentService.Object)
-        {
-            ControllerContext = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext()
-            }
-        };
+                      {
+                          ControllerContext = new ControllerContext
+                                              {
+                                                  HttpContext = new DefaultHttpContext()
+                                              }
+                      };
     }
 
     [TestMethod]
@@ -36,10 +38,11 @@ public class QualificationDetailsControllerTests
     {
         var result = await _controller!.Index(string.Empty);
 
-        Assert.IsNotNull(result);
+        result.Should().NotBeNull();
+
         var resultType = result as BadRequestResult;
-        Assert.IsNotNull(resultType);
-        Assert.AreEqual(400, resultType.StatusCode);
+        resultType.Should().NotBeNull();
+        resultType!.StatusCode.Should().Be(400);
     }
 
     [TestMethod]
@@ -50,35 +53,40 @@ public class QualificationDetailsControllerTests
         _mockContentService.Setup(x => x.GetDetailsPage()).ReturnsAsync(new DetailsPage());
         var result = await _controller!.Index(qualificationId);
 
-        Assert.IsNotNull(result);
+        result.Should().NotBeNull();
+
         var resultType = result as RedirectToActionResult;
-        Assert.IsNotNull(resultType);
-        Assert.AreEqual("Error", resultType.ActionName);
-        Assert.AreEqual("Home", resultType.ControllerName);
+        resultType.Should().NotBeNull();
+        resultType!.ActionName.Should().Be("Error");
+        resultType.ControllerName.Should().Be("Home");
     }
 
     [TestMethod]
     public async Task Index_ContentServiceReturnsQualification_ReturnsQualificationDetailsModel()
     {
         const string qualificationId = "eyq-145";
-        var qualificationResult = new Qualification(qualificationId, "Qualification Name", "NCFE", 2, "2014", "2019", "ABC/547/900", "notes", "additonal requirements");
+        var qualificationResult = new Qualification(qualificationId, "Qualification Name", "NCFE", 2, "2014", "2019",
+                                                    "ABC/547/900", "notes", "additonal requirements");
         _mockContentService.Setup(x => x.GetQualificationById(qualificationId)).ReturnsAsync(qualificationResult);
         _mockContentService.Setup(x => x.GetDetailsPage()).ReturnsAsync(new DetailsPage());
         var result = await _controller!.Index(qualificationId);
 
-        Assert.IsNotNull(result);
+        result.Should().NotBeNull();
+
         var resultType = result as ViewResult;
-        Assert.IsNotNull(resultType);
-        var model = resultType.Model as QualificationDetailsModel;
-        Assert.IsNotNull(model);
-        Assert.AreEqual(qualificationResult.QualificationId, model.QualificationId);
-        Assert.AreEqual(qualificationResult.QualificationName, model.QualificationName);
-        Assert.AreEqual(qualificationResult.AwardingOrganisationTitle, model.AwardingOrganisationTitle);
-        Assert.AreEqual(qualificationResult.QualificationLevel, model.QualificationLevel);
-        Assert.AreEqual(qualificationResult.FromWhichYear, model.FromWhichYear);
-        Assert.AreEqual(qualificationResult.ToWhichYear, model.ToWhichYear);
-        Assert.AreEqual(qualificationResult.QualificationNumber, model.QualificationNumber);
-        Assert.AreEqual(qualificationResult.Notes, model.Notes);
-        Assert.AreEqual(qualificationResult.AdditionalRequirements, model.AdditionalRequirements);
+        resultType.Should().NotBeNull();
+
+        var model = resultType!.Model as QualificationDetailsModel;
+        model.Should().NotBeNull();
+
+        model!.QualificationId.Should().Be(qualificationResult.QualificationId);
+        model.QualificationName.Should().Be(qualificationResult.QualificationName);
+        model.AwardingOrganisationTitle.Should().Be(qualificationResult.AwardingOrganisationTitle);
+        model.QualificationLevel.Should().Be(qualificationResult.QualificationLevel);
+        model.FromWhichYear.Should().Be(qualificationResult.FromWhichYear);
+        model.ToWhichYear.Should().Be(qualificationResult.ToWhichYear);
+        model.QualificationNumber.Should().Be(qualificationResult.QualificationNumber);
+        model.Notes.Should().Be(qualificationResult.Notes);
+        model.AdditionalRequirements.Should().Be(qualificationResult.AdditionalRequirements);
     }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/ViewComponents/FooterLinksViewComponentTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/ViewComponents/FooterLinksViewComponentTests.cs
@@ -1,6 +1,7 @@
 ﻿using Dfe.EarlyYearsQualification.Content.Entities;
 using Dfe.EarlyYearsQualification.Content.Services;
 using Dfe.EarlyYearsQualification.Web.ViewComponents;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,9 +12,11 @@ namespace Dfe.EarlyYearsQualification.UnitTests.ViewComponents;
 [TestClass]
 public class FooterLinksViewComponentTests
 {
-    private ILogger<FooterLinksViewComponent> _mockLogger = new NullLoggerFactory().CreateLogger<FooterLinksViewComponent>();
     private Mock<IContentService> _mockContentService = new();
-    
+
+    private ILogger<FooterLinksViewComponent> _mockLogger =
+        new NullLoggerFactory().CreateLogger<FooterLinksViewComponent>();
+
     [TestInitialize]
     public void BeforeTestRun()
     {
@@ -24,21 +27,24 @@ public class FooterLinksViewComponentTests
     [TestMethod]
     public async Task InvokeAsync_CallsContentService_ReturnsNavigationLinks()
     {
-        var navigationLink = new NavigationLink { DisplayText = "Test", Href = "https://test.com", OpenInNewTab = true };
+        var navigationLink = new NavigationLink
+                             { DisplayText = "Test", Href = "https://test.com", OpenInNewTab = true };
 
-        _mockContentService.Setup(x => x.GetNavigationLinks()).ReturnsAsync(new List<NavigationLink> { navigationLink });
+        _mockContentService.Setup(x => x.GetNavigationLinks())
+                           .ReturnsAsync(new List<NavigationLink> { navigationLink });
 
         var footerLinksViewComponent = new FooterLinksViewComponent(_mockContentService.Object, _mockLogger);
         var result = await footerLinksViewComponent.InvokeAsync();
 
-        Assert.IsNotNull(result);
+        result.Should().NotBeNull();
+
         var model = (result as ViewViewComponentResult)?.ViewData?.Model;
-        Assert.IsNotNull(model);
+        model.Should().NotBeNull();
 
         var data = model as List<NavigationLink>;
-        Assert.IsNotNull(data);
+        data.Should().NotBeNull();
 
-        Assert.AreEqual(navigationLink.DisplayText, data[0].DisplayText);
+        data![0].DisplayText.Should().Be(navigationLink.DisplayText);
     }
 
     [TestMethod]
@@ -49,12 +55,13 @@ public class FooterLinksViewComponentTests
         var footerLinksViewComponent = new FooterLinksViewComponent(_mockContentService.Object, _mockLogger);
         var result = await footerLinksViewComponent.InvokeAsync();
 
-        Assert.IsNotNull(result);
+        result.Should().NotBeNull();
+
         var model = (result as ViewViewComponentResult)?.ViewData?.Model;
-        Assert.IsNotNull(model);
+        model.Should().NotBeNull();
 
         var data = model as List<NavigationLink>;
-        Assert.IsNull(data);
+        data.Should().BeNull(); // question: should data instead be an empty list?
     }
 
     [TestMethod]
@@ -65,11 +72,12 @@ public class FooterLinksViewComponentTests
         var footerLinksViewComponent = new FooterLinksViewComponent(_mockContentService.Object, _mockLogger);
         var result = await footerLinksViewComponent.InvokeAsync();
 
-        Assert.IsNotNull(result);
+        result.Should().NotBeNull();
+
         var model = (result as ViewViewComponentResult)?.ViewData?.Model;
-        Assert.IsNotNull(model);
+        model.Should().NotBeNull();
 
         var data = model as List<NavigationLink>;
-        Assert.IsNull(data);
+        data.Should().BeNull(); // question: should data instead be an empty list?
     }
 }


### PR DESCRIPTION
# Description

Swap to FluentAssertions, as agreed by the team.

## Ticket number (if applicable)

EYQB-209

# How Has This Been Tested?

All tests pass locally. Pages look OK.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules