### PR TITLE
Feature/navigation links refactor

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Content/Entities/NavigationLinks.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/NavigationLinks.cs
@@ -1,0 +1,6 @@
+namespace Dfe.EarlyYearsQualification.Content.Entities;
+
+public class NavigationLinks
+{
+  public List<NavigationLink> Links { get; init; } = [];
+}

--- a/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentService.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentService.cs
@@ -18,12 +18,12 @@ public class ContentfulContentService : IContentService
     private readonly Dictionary<object, string> _contentTypes = new()
     {
         {typeof(StartPage), "startPage"},
-        {typeof(NavigationLink), "navigationLink"},
         {typeof(Qualification), "Qualification"},
         {typeof(DetailsPage), "detailsPage"},
         {typeof(AdvicePage), "advicePage"},
         {typeof(QuestionPage), "questionPage"},
-        {typeof(AccessibilityStatementPage), "accessibilityStatementPage"}
+        {typeof(AccessibilityStatementPage), "accessibilityStatementPage"},
+        {typeof(NavigationLinks), "navigationLinks"}
     };
 
     public ContentfulContentService(IContentfulClient contentfulClient, ILogger<ContentfulContentService> logger)
@@ -80,10 +80,10 @@ public class ContentfulContentService : IContentService
 
     public async Task<List<NavigationLink>?> GetNavigationLinks()
     {
-        var navigationLinkEntries = await GetEntriesByType<NavigationLink>();
+        var navigationLinkEntries = await GetEntriesByType<NavigationLinks>();
         if (navigationLinkEntries is not null && navigationLinkEntries.Any())
         {
-            return navigationLinkEntries.ToList();
+            return navigationLinkEntries.First().Links;
         }
 
         _logger.LogWarning("No navigation links returned");

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Extensions/MockLoggerExtensions.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Extensions/MockLoggerExtensions.cs
@@ -16,4 +16,16 @@ public static class MockLoggerExtensions
         It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
     Times.Once);
   }
+
+  public static void VerifyWarning<T>(this Mock<ILogger<T>> mockLogger, string message)
+  {
+    mockLogger.Verify(
+    logger => logger.Log(
+        LogLevel.Warning,
+        It.IsAny<EventId>(),
+        It.Is<It.IsAnyType>((@object, _) => @object.ToString() == message),
+        It.IsAny<Exception>(),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+    Times.Once);
+  }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentServiceTests.cs
@@ -14,10 +14,12 @@ namespace Dfe.EarlyYearsQualification.UnitTests.Services;
 public class ContentfulContentServiceTests
 {
   private readonly Mock<ILogger<ContentfulContentService>> _logger;
+  private readonly  Mock<IContentfulClient> _clientMock;
 
   public ContentfulContentServiceTests()
   {
     _logger = new Mock<ILogger<ContentfulContentService>>();
+    _clientMock = new Mock<IContentfulClient>();
   }
 
   [TestMethod]
@@ -27,15 +29,14 @@ public class ContentfulContentServiceTests
 
     var pages = new ContentfulCollection<StartPage> { Items = new[] { startPage } };
 
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<StartPage>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync(pages);
 
-    var service = new ContentfulContentService(clientMock.Object, _logger.Object);
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetStartPage().Result;
 
@@ -49,15 +50,14 @@ public class ContentfulContentServiceTests
     var pages = new ContentfulCollection<StartPage> { Items = new List<StartPage>() };
     // NB: If "pages.Items" is ever null, the iterator built into ContentfulCollection will throw an exception
 
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<StartPage>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync(pages);
 
-    var service = new ContentfulContentService(clientMock.Object, _logger.Object);
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetStartPage().Result;
 
@@ -69,15 +69,14 @@ public class ContentfulContentServiceTests
   [TestMethod]
   public void GetStartPage_NullPages_ReturnsNull()
   {
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<StartPage>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync((ContentfulCollection<StartPage>)null!);
 
-    var service = new ContentfulContentService(clientMock.Object, _logger.Object);
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetStartPage().Result;
 
@@ -91,15 +90,14 @@ public class ContentfulContentServiceTests
   {
     var pages = new ContentfulCollection<AccessibilityStatementPage> { Items = new List<AccessibilityStatementPage>() };
 
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<AccessibilityStatementPage>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync(pages);
 
-    var service = new ContentfulContentService(clientMock.Object, _logger.Object);
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetAccessibilityStatementPage().Result;
 
@@ -111,15 +109,14 @@ public class ContentfulContentServiceTests
   [TestMethod]
   public void GetAccessibilityStatementPage_NullPages_ReturnsNull()
   {
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<AccessibilityStatementPage>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync((ContentfulCollection<AccessibilityStatementPage>)null!);
 
-    var service = new ContentfulContentService(clientMock.Object, _logger.Object);
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetAccessibilityStatementPage().Result;
 
@@ -135,15 +132,14 @@ public class ContentfulContentServiceTests
 
     var pages = new ContentfulCollection<AccessibilityStatementPage> { Items = new[] { accessibilityStatementPage } };
 
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<AccessibilityStatementPage>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync(pages);
 
-    var service = new ContentfulContentService(clientMock.Object, _logger.Object);
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetAccessibilityStatementPage().Result;
 
@@ -156,17 +152,18 @@ public class ContentfulContentServiceTests
   {
     var pages = new ContentfulCollection<CookiesPage> { Items = new List<CookiesPage>() };
 
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<CookiesPage>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync(pages);
 
-    var service = new ContentfulContentService(clientMock.Object, new NullLogger<ContentfulContentService>());
+    var service = new ContentfulContentService(_clientMock.Object,_logger.Object);
 
     var result = service.GetCookiesPage().Result;
+
+    _logger.VerifyWarning("No cookies page entry returned");
 
     result.Should().BeNull();
   }
@@ -174,17 +171,18 @@ public class ContentfulContentServiceTests
   [TestMethod]
   public void GetCookiesPage_NullPages_ReturnsNull()
   {
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<CookiesPage>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync((ContentfulCollection<CookiesPage>)null!);
 
-    var service = new ContentfulContentService(clientMock.Object, new NullLogger<ContentfulContentService>());
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetCookiesPage().Result;
+
+    _logger.VerifyWarning("No cookies page entry returned");
 
     result.Should().BeNull();
   }
@@ -196,15 +194,14 @@ public class ContentfulContentServiceTests
 
     var pages = new ContentfulCollection<CookiesPage> { Items = new[] { cookiesPage } };
 
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<CookiesPage>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync(pages);
 
-    var service = new ContentfulContentService(clientMock.Object, new NullLogger<ContentfulContentService>());
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetCookiesPage().Result;
 
@@ -215,15 +212,14 @@ public class ContentfulContentServiceTests
   [TestMethod]
   public void GetNavigationLinks_NoContent_LogsWarningAndReturns()
   {
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<NavigationLinks>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync(new ContentfulCollection<NavigationLinks> { Items = new List<NavigationLinks>() });
 
-    var service = new ContentfulContentService(clientMock.Object, _logger.Object);
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetNavigationLinks().Result;
 
@@ -235,15 +231,14 @@ public class ContentfulContentServiceTests
   [TestMethod]
   public void GetNavigationLinks_Null_LogsWarningAndReturns()
   {
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<NavigationLinks>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync((ContentfulCollection<NavigationLinks>)null!);
 
-    var service = new ContentfulContentService(clientMock.Object, _logger.Object);
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetNavigationLinks().Result;
 
@@ -273,15 +268,14 @@ public class ContentfulContentServiceTests
 
     var content = new ContentfulCollection<NavigationLinks>() { Items = [new NavigationLinks() { Links = links }] };
 
-    var clientMock = new Mock<IContentfulClient>();
-    clientMock.Setup(client =>
+    _clientMock.Setup(client =>
                          client.GetEntriesByType(
                                                  It.IsAny<string>(),
                                                  It.IsAny<QueryBuilder<NavigationLinks>>(),
                                                  It.IsAny<CancellationToken>()))
               .ReturnsAsync(content);
 
-    var service = new ContentfulContentService(clientMock.Object, _logger.Object);
+    var service = new ContentfulContentService(_clientMock.Object, _logger.Object);
 
     var result = service.GetNavigationLinks().Result;
 

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentServiceTests.cs
@@ -13,10 +13,11 @@ namespace Dfe.EarlyYearsQualification.UnitTests.Services;
 [TestClass]
 public class ContentfulContentServiceTests
 {
-  private readonly Mock<ILogger<ContentfulContentService>> _logger;
-  private readonly  Mock<IContentfulClient> _clientMock;
+  private Mock<ILogger<ContentfulContentService>> _logger = new ();
+  private Mock<IContentfulClient> _clientMock = new ();
 
-  public ContentfulContentServiceTests()
+  [TestInitialize]
+  public void BeforeEachTest()
   {
     _logger = new Mock<ILogger<ContentfulContentService>>();
     _clientMock = new Mock<IContentfulClient>();
@@ -281,5 +282,7 @@ public class ContentfulContentServiceTests
 
     result.Should().NotBeNull();
     result.Should().BeSameAs(links);
+
+    
   }
 }


### PR DESCRIPTION
# Description

- added new NavigationLinks model to code and Contentful. Allows us to specify the order the links appear from Contentful.

- small refactor of tests of the Contentful client service. Added tests for logger, broke out instantiation of client into Ctor + more.

## Ticket number (if applicable)

# How Has This Been Tested?

- Manually tested locally via changing order in Contentful.
- new and existing Unit tests + existing E2E tests passing.

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [N/A] Any dependent changes have been merged and published in downstream modules