### PR TITLE
added css to allow 'footer to fill bottom of page'

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html lang="en">
+<html class="govuk-template" lang="en">
 
 <head>
     <meta charset="utf-8"/>


### PR DESCRIPTION
# Description

- Added a CSS class to the main HTML tag.

- It essentially adds the footer colour as the main background color, giving the illusion of the footer filling the bottom of the page!

## Ticket number (if applicable)

# How Has This Been Tested?

- Tested locally - see screenshots
- new and existing tests passing

# Screenshots

Before:
![image](https://github.com/DFE-Digital/check-an-early-years-qualification/assets/157381612/1bfd6b38-e6d6-489a-86a0-3317b6290abf)

After:
![image](https://github.com/DFE-Digital/check-an-early-years-qualification/assets/157381612/1a2d558e-1faa-412b-8b04-802d48910eaa)

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules