### PR TITLE
Contentful secrets refactor

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -38,6 +38,16 @@ jobs:
               with:
                 ref: ${{ github.ref }}
 
+            - name: App Settings Variable Substitution
+              uses: microsoft/variable-substitution@v1
+              with:
+                files: 'src/Dfe.EarlyYearsQualification.Web/appsettings.json'
+              env:
+                ContentfulOptions.DeliveryApiKey: ${{ secrets.CONTENTFUL_DELIVERY_API_KEY }}
+                ContentfulOptions.PreviewApiKey: ${{ secrets.CONTENTFUL_PREVIEW_API_KEY }}
+                ContentfulOptions.SpaceId: ${{ secrets.CONTENTFUL_SPACE_ID }}
+                ContentfulOptions.UsePreviewApi: ${{ vars.CONTENTFUL_USE_PREVIEW_API }}
+
             - name: GitHub Container Registry Login
               uses: docker/login-action@v3
               with:

--- a/src/Dfe.EarlyYearsQualification.Web/Dfe.EarlyYearsQualification.Web.csproj
+++ b/src/Dfe.EarlyYearsQualification.Web/Dfe.EarlyYearsQualification.Web.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-    </PropertyGroup>
+    <UserSecretsId>Dfe.EarlyYearsQualification.Web</UserSecretsId>
+  </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />

--- a/src/Dfe.EarlyYearsQualification.Web/Program.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Program.cs
@@ -16,18 +16,6 @@ using RobotsTxt;
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.ConfigureKestrel(serverOptions => { serverOptions.AddServerHeader = false; });
 
-if (!builder.Configuration.GetValue<bool>("UseMockContentful"))
-{
-    var keyVaultEndpoint = builder.Configuration.GetSection("KeyVault").GetValue<string>("Endpoint");
-    builder.Configuration.AddAzureKeyVault(new Uri(keyVaultEndpoint!), new DefaultAzureCredential());
-
-    var blobStorageConnectionString = builder.Configuration.GetSection("Storage").GetValue<string>("ConnectionString");
-    builder.Services.AddDataProtection()
-           .PersistKeysToAzureBlobStorage(blobStorageConnectionString, "data-protection", "data-protection")
-           .ProtectKeysWithAzureKeyVault(new Uri($"{keyVaultEndpoint}keys/data-protection"),
-                                         new DefaultAzureCredential());
-}
-
 // Add services to the container.
 builder.Services.AddControllersWithViews(options =>
                                          {

--- a/src/Dfe.EarlyYearsQualification.Web/appsettings.json
+++ b/src/Dfe.EarlyYearsQualification.Web/appsettings.json
@@ -6,9 +6,6 @@
     }
   },
   "ContentfulOptions": {
-    "DeliveryApiKey": "Retrieved from KeyVault",
-    "PreviewApiKey": "Retrieved from KeyVault",
-    "SpaceId": "Retrieved from KeyVault",
     "UsePreviewApi": false,
     "MaxNumberOfRateLimitRetries": 1
   },

--- a/src/Dfe.EarlyYearsQualification.Web/set-contentful-secrets.sh
+++ b/src/Dfe.EarlyYearsQualification.Web/set-contentful-secrets.sh
@@ -1,0 +1,11 @@
+dotnet user-secrets init --id "Dfe.EarlyYearsQualification.Web"
+
+read -p "Enter Delivery API key: " deliveryApiKey
+
+read -p "Enter Preview API Key: " previewApiKey
+
+read -p "Enter Space ID: " spaceID
+
+dotnet user-secrets set "ContentfulOptions:DeliveryApiKey" "$deliveryApiKey"
+dotnet user-secrets set "ContentfulOptions:PreviewApiKey" "$previewApiKey"
+dotnet user-secrets set "ContentfulOptions:SpaceId" "$spaceID"


### PR DESCRIPTION
# Description

- Contentful secrets are now set in GitHub secrets, and are being pulled in and set in actions dependent on the environment.
- Contentful secrets locally will now be stored in dotnet secrets, I've added a .sh script to help with setting these

## Ticket number (if applicable)

https://dfedigital.atlassian.net/browse/EYQB-243

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [ ] My code follows the standards used within this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules