### PR TITLE
chore/avoid-nullable-navlinks

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentService.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentService.cs
@@ -79,7 +79,7 @@ public class ContentfulContentService(
         return cookiesContent;
     }
 
-    public async Task<List<NavigationLink>?> GetNavigationLinks()
+    public async Task<List<NavigationLink>> GetNavigationLinks()
     {
         var navigationLinkEntries = await GetEntriesByType<NavigationLinks>();
         if (navigationLinkEntries is not null && navigationLinkEntries.Any())
@@ -88,7 +88,7 @@ public class ContentfulContentService(
         }
 
         logger.LogWarning("No navigation links returned");
-        return default;
+        return [];
     }
 
     public async Task<Qualification?> GetQualificationById(string qualificationId)
@@ -127,12 +127,12 @@ public class ContentfulContentService(
         return await GetEntryById<RadioQuestionPage>(entryId);
     }
 
-    public async Task<DateQuestionPage?> GetDateQuestionPage(string entryId) 
+    public async Task<DateQuestionPage?> GetDateQuestionPage(string entryId)
     {
         return await GetEntryById<DateQuestionPage>(entryId);
     }
-    
-    public async Task<DropdownQuestionPage?> GetDropdownQuestionPage(string entryId) 
+
+    public async Task<DropdownQuestionPage?> GetDropdownQuestionPage(string entryId)
     {
         return await GetEntryById<DropdownQuestionPage>(entryId);
     }

--- a/src/Dfe.EarlyYearsQualification.Content/Services/IContentService.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/IContentService.cs
@@ -6,7 +6,7 @@ public interface IContentService
 {
     Task<StartPage?> GetStartPage();
 
-    Task<List<NavigationLink>?> GetNavigationLinks();
+    Task<List<NavigationLink>> GetNavigationLinks();
 
     Task<Qualification?> GetQualificationById(string qualificationId);
 

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
@@ -22,14 +22,17 @@ public class MockContentfulService : IContentService
     public async Task<AdvicePage?> GetAdvicePage(string entryId)
     {
         var body = ContentfulContentHelper.Paragraph("Test Advice Page Body");
-        
+
         return entryId switch
                {
-                     AdvicePages.QualificationsAchievedOutsideTheUk => 
-                        await Task.FromResult(CreateAdvicePage("Qualifications achieved outside the United Kingdom", body)),
-                     AdvicePages.QualificationsStartedBetweenSept2014AndAug2019 => 
-                         await Task.FromResult(CreateAdvicePage("Level 2 qualifications started between 1 September 2014 and 31 August 2019", body)),
-                     _ => throw new NotImplementedException($"No advice page mock for entry {entryId}")
+                   AdvicePages.QualificationsAchievedOutsideTheUk =>
+                       await Task.FromResult(CreateAdvicePage("Qualifications achieved outside the United Kingdom",
+                                                              body)),
+                   AdvicePages.QualificationsStartedBetweenSept2014AndAug2019 =>
+                       await
+                           Task.FromResult(CreateAdvicePage("Level 2 qualifications started between 1 September 2014 and 31 August 2019",
+                                                            body)),
+                   _ => throw new NotImplementedException($"No advice page mock for entry {entryId}")
                };
     }
 
@@ -83,7 +86,7 @@ public class MockContentfulService : IContentService
                                      });
     }
 
-    public async Task<List<NavigationLink>?> GetNavigationLinks()
+    public async Task<List<NavigationLink>> GetNavigationLinks()
     {
         return await Task.FromResult(new List<NavigationLink>
                                      {
@@ -141,7 +144,7 @@ public class MockContentfulService : IContentService
 
     public async Task<DateQuestionPage?> GetDateQuestionPage(string entryId)
     {
-      return entryId switch
+        return entryId switch
                {
                    QuestionPages.WhenWasTheQualificationStarted =>
                        await Task.FromResult(CreateDateQuestionPage()),
@@ -273,15 +276,15 @@ public class MockContentfulService : IContentService
 
     private static DateQuestionPage CreateDateQuestionPage()
     {
-      return new DateQuestionPage
-              {
-                Question = "Test Date Question",
-                CtaButtonText = "Continue",
-                ErrorMessage = "Test Error Message",
-                MonthLabel = "Test Month Label",
-                YearLabel = "Test Year Label",
-                QuestionHint = "Test Question Hint"
-              };
+        return new DateQuestionPage
+               {
+                   Question = "Test Date Question",
+                   CtaButtonText = "Continue",
+                   ErrorMessage = "Test Error Message",
+                   MonthLabel = "Test Month Label",
+                   YearLabel = "Test Year Label",
+                   QuestionHint = "Test Question Hint"
+               };
     }
 
     private static DropdownQuestionPage CreateDropdownPage()
@@ -296,7 +299,7 @@ public class MockContentfulService : IContentService
                    NotInListText = "Test Not In The List"
                };
     }
-    
+
     private static AdvicePage CreateAdvicePage(string heading, Document body)
     {
         return new AdvicePage

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
@@ -32,7 +32,7 @@ public class MockContentfulService : IContentService
                        await
                            Task.FromResult(CreateAdvicePage("Level 2 qualifications started between 1 September 2014 and 31 August 2019",
                                                             body)),
-                   _ => throw new NotImplementedException($"No advice page mock for entry {entryId}")
+                   _ => null
                };
     }
 

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
@@ -85,7 +85,7 @@ public class QuestionsController(
             return View("Date", model);
         }
         
-        userJourneyCookieService.SetWhenWasQualificationAwarded(model.SelectedMonth.ToString() + '/' + model.SelectedYear.ToString());
+        userJourneyCookieService.SetWhenWasQualificationAwarded(model.SelectedMonth.ToString() + '/' + model.SelectedYear);
 
         return RedirectToAction(nameof(this.WhatLevelIsTheQualification));
     }
@@ -213,7 +213,7 @@ public class QuestionsController(
         model.DropdownHeading = question.DropdownHeading;
         model.NotInListText = question.NotInListText;
         
-        model.Values.Add(new SelectListItem()
+        model.Values.Add(new SelectListItem
                          {
                              Text = question.DefaultText,
                              Value = ""
@@ -221,7 +221,7 @@ public class QuestionsController(
        
        foreach (var awardingOrg in uniqueAwardingOrganisations)
        {
-           model.Values.Add(new SelectListItem()
+           model.Values.Add(new SelectListItem
                             {
                                 Value = awardingOrg,
                                 Text = awardingOrg

--- a/src/Dfe.EarlyYearsQualification.Web/ViewComponents/FooterLinksViewComponent.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/ViewComponents/FooterLinksViewComponent.cs
@@ -4,7 +4,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.EarlyYearsQualification.Web.ViewComponents;
 
-public class FooterLinksViewComponent(IContentService contentService, ILogger<FooterLinksViewComponent> logger) : ViewComponent
+public class FooterLinksViewComponent(IContentService contentService, ILogger<FooterLinksViewComponent> logger)
+    : ViewComponent
 {
     public async Task<IViewComponentResult> InvokeAsync()
     {
@@ -17,13 +18,7 @@ public class FooterLinksViewComponent(IContentService contentService, ILogger<Fo
     {
         try
         {
-            var navigationLinks = await contentService.GetNavigationLinks();
-            if (navigationLinks is null || navigationLinks.Count == 0)
-            {
-                return await Task.FromResult(Array.Empty<NavigationLink>().AsEnumerable());
-            }
-
-            return navigationLinks;
+            return await contentService.GetNavigationLinks();
         }
         catch (Exception ex)
         {

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -473,7 +473,7 @@ public class QuestionsControllerTests
         
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object, mockUserJourneyCookieService.Object);
 
-        var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel()
+        var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel
                                                                   {
                                                                       Option = "2"
                                                                   });
@@ -524,7 +524,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         
-        var questionPage = new DropdownQuestionPage()
+        var questionPage = new DropdownQuestionPage
                            {
                                Question = "Test question",
                                CtaButtonText = "Continue",
@@ -556,9 +556,9 @@ public class QuestionsControllerTests
         model.ErrorMessage.Should().Be(questionPage.ErrorMessage);
         model.DropdownHeading.Should().Be(questionPage.DropdownHeading);
         model.HasErrors.Should().BeFalse();
-        model.Values.Count().Should().Be(1);
-        model.Values.First().Text.Should().Be(questionPage.DefaultText);
-        model.Values.First().Value.Should().BeEmpty();
+        model.Values.Count.Should().Be(1);
+        model.Values[0].Text.Should().Be(questionPage.DefaultText);
+        model.Values[0].Value.Should().BeEmpty();
         model.NotInListText.Should().Be(questionPage.NotInListText);
     }
     
@@ -570,7 +570,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
 
-        var questionPage = new DropdownQuestionPage()
+        var questionPage = new DropdownQuestionPage
                            {
                                DefaultText = "Test default text"
                            };
@@ -614,8 +614,8 @@ public class QuestionsControllerTests
 
         // Count here includes default value added in mapping
         model.Values.Count.Should().Be(6);
-        model.Values.First().Text.Should().Be(questionPage.DefaultText);
-        model.Values.First().Value.Should().BeEmpty();
+        model.Values[0].Text.Should().Be(questionPage.DefaultText);
+        model.Values[0].Value.Should().BeEmpty();
 
         model.Values[1].Text.Should().Be("A awarding organisation");
         model.Values[2].Text.Should().Be("B awarding organisation");
@@ -634,7 +634,7 @@ public class QuestionsControllerTests
         
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object, mockUserJourneyCookieService.Object);
 
-        var questionPage = new DropdownQuestionPage()
+        var questionPage = new DropdownQuestionPage
                            {
                                Question = "Test question",
                                CtaButtonText = "Continue",
@@ -677,7 +677,7 @@ public class QuestionsControllerTests
         
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object, mockUserJourneyCookieService.Object);
         
-        var result = await controller.WhatIsTheAwardingOrganisation(new DropdownQuestionModel()
+        var result = await controller.WhatIsTheAwardingOrganisation(new DropdownQuestionModel
                                                                     {
                                                                         SelectedValue = string.Empty,
                                                                         NotInTheList = false
@@ -703,7 +703,7 @@ public class QuestionsControllerTests
         
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object, mockUserJourneyCookieService.Object);
 
-        var questionPage = new DropdownQuestionPage()
+        var questionPage = new DropdownQuestionPage
                            {
                                Question = "Test question",
                                CtaButtonText = "Continue",
@@ -718,7 +718,7 @@ public class QuestionsControllerTests
         
         mockContentService.Setup(x => x.GetQualifications()).ReturnsAsync([]);
         
-        var result = await controller.WhatIsTheAwardingOrganisation(new DropdownQuestionModel()
+        var result = await controller.WhatIsTheAwardingOrganisation(new DropdownQuestionModel
                                                                     {
                                                                         SelectedValue = "Some Awarding Organisation",
                                                                         NotInTheList = false
@@ -746,7 +746,7 @@ public class QuestionsControllerTests
         
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object, mockUserJourneyCookieService.Object);
 
-        var questionPage = new DropdownQuestionPage()
+        var questionPage = new DropdownQuestionPage
                            {
                                Question = "Test question",
                                CtaButtonText = "Continue",
@@ -761,7 +761,7 @@ public class QuestionsControllerTests
         
         mockContentService.Setup(x => x.GetQualifications()).ReturnsAsync([]);
         
-        var result = await controller.WhatIsTheAwardingOrganisation(new DropdownQuestionModel()
+        var result = await controller.WhatIsTheAwardingOrganisation(new DropdownQuestionModel
                                                                     {
                                                                         SelectedValue = "",
                                                                         NotInTheList = true

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
@@ -108,7 +108,7 @@ public class MockContentfulServiceTests
         var result = await contentfulService.GetNavigationLinks();
         result.Should().NotBeNull();
         result.Should().BeAssignableTo<List<NavigationLink>>();
-        result!.Count.Should().Be(2);
+        result.Count.Should().Be(2);
     }
 
     [TestMethod]
@@ -204,7 +204,7 @@ public class MockContentfulServiceTests
         await act.Should().ThrowAsync<NotImplementedException>()
                  .WithMessage("No date question page mock for entry Fake_entry_id");
     }
-    
+
     [TestMethod]
     public async Task GetDropdownQuestionPage_PassWhenWasQualificationStartedId_ReturnsExpectedDetails()
     {

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
@@ -50,11 +50,10 @@ public class MockContentfulServiceTests
     public async Task GetAdvicePage_UnknownEntryId_ReturnsException()
     {
         var contentfulService = new MockContentfulService();
+        
+        var page = await contentfulService.GetAdvicePage("Invalid entry Id");
 
-        Func<Task> act = async () => await contentfulService.GetAdvicePage("Invalid entry Id");
-
-        await act.Should().ThrowAsync<NotImplementedException>()
-                 .WithMessage("No advice page mock for entry Invalid entry Id");
+        page.Should().BeNull();
     }
 
     [TestMethod]

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentServiceTests.cs
@@ -246,7 +246,7 @@ public class ContentfulContentServiceTests
 
         _logger.VerifyWarning("No navigation links returned");
 
-        result.Should().BeNull();
+        result.Should().BeEmpty();
     }
 
     [TestMethod]
@@ -265,7 +265,7 @@ public class ContentfulContentServiceTests
 
         _logger.VerifyWarning("No navigation links returned");
 
-        result.Should().BeNull();
+        result.Should().BeEmpty();
     }
 
     [TestMethod]

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/UserJourneyCookieServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/UserJourneyCookieServiceTests.cs
@@ -18,73 +18,73 @@ public class UserJourneyCookieServiceTests
         var modelInCookie = new UserJourneyModel();
         var mockHttpContextAccessor = SetHttpContextWithExistingCookie(modelInCookie);
         var mockLogger = new Mock<ILogger<UserJourneyCookieService>>();
-        
+
         var service = new UserJourneyCookieService(mockHttpContextAccessor.Object, mockLogger.Object);
-        
+
         service.SetWhereWasQualificationAwarded("some test string");
-        
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel()
+
+        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
                                                               {
                                                                   WhereWasQualificationAwarded = "some test string"
                                                               });
-        
+
         CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
     }
-    
+
     [TestMethod]
     public void SetWhenWasQualificationAwarded_StringProvided_SetsCookieCorrectly()
     {
         var modelInCookie = new UserJourneyModel();
         var mockHttpContextAccessor = SetHttpContextWithExistingCookie(modelInCookie);
         var mockLogger = new Mock<ILogger<UserJourneyCookieService>>();
-        
+
         var service = new UserJourneyCookieService(mockHttpContextAccessor.Object, mockLogger.Object);
-        
+
         service.SetWhenWasQualificationAwarded("some test string");
-        
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel()
+
+        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
                                                               {
                                                                   WhenWasQualificationAwarded = "some test string"
                                                               });
-        
+
         CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
     }
-    
+
     [TestMethod]
     public void SetLevelOfQualification_StringProvided_SetsCookieCorrectly()
     {
         var modelInCookie = new UserJourneyModel();
         var mockHttpContextAccessor = SetHttpContextWithExistingCookie(modelInCookie);
         var mockLogger = new Mock<ILogger<UserJourneyCookieService>>();
-        
+
         var service = new UserJourneyCookieService(mockHttpContextAccessor.Object, mockLogger.Object);
-        
+
         service.SetLevelOfQualification("some test string");
-        
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel()
+
+        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
                                                               {
                                                                   LevelOfQualification = "some test string"
                                                               });
-        
+
         CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
     }
-    
+
     [TestMethod]
     public void SetAwardingOrganisation_StringProvided_SetsCookieCorrectly()
     {
         var modelInCookie = new UserJourneyModel();
         var mockHttpContextAccessor = SetHttpContextWithExistingCookie(modelInCookie);
         var mockLogger = new Mock<ILogger<UserJourneyCookieService>>();
-        
+
         var service = new UserJourneyCookieService(mockHttpContextAccessor.Object, mockLogger.Object);
-        
+
         service.SetAwardingOrganisation("some test string");
-        
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel()
+
+        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
                                                               {
                                                                   WhatIsTheAwardingOrganisation = "some test string"
                                                               });
-        
+
         CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
     }
 
@@ -93,7 +93,7 @@ public class UserJourneyCookieServiceTests
     {
         var mockHttpContextAccessor = SetHttpContextWithExistingCookie(null);
         var mockLogger = new Mock<ILogger<UserJourneyCookieService>>();
-        
+
         var service = new UserJourneyCookieService(mockHttpContextAccessor.Object, mockLogger.Object);
 
         var model = service.GetUserJourneyModelFromCookie();
@@ -105,19 +105,19 @@ public class UserJourneyCookieServiceTests
         var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel());
         CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
     }
-    
+
     [TestMethod]
     public void GetUserJourneyModelFromCookie_CookieModelSerializesOK_SetsCookieAsProvidedModel()
     {
-        var existingModel = new UserJourneyModel()
-                    {
-                        LevelOfQualification = "test level of qualification",
-                        WhenWasQualificationAwarded = "test when was qualification awarded",
-                        WhereWasQualificationAwarded = "test where was qualification awarded"
-                    };
+        var existingModel = new UserJourneyModel
+                            {
+                                LevelOfQualification = "test level of qualification",
+                                WhenWasQualificationAwarded = "test when was qualification awarded",
+                                WhereWasQualificationAwarded = "test where was qualification awarded"
+                            };
         var mockHttpContextAccessor = SetHttpContextWithExistingCookie(existingModel);
         var mockLogger = new Mock<ILogger<UserJourneyCookieService>>();
-        
+
         var service = new UserJourneyCookieService(mockHttpContextAccessor.Object, mockLogger.Object);
 
         var model = service.GetUserJourneyModelFromCookie();
@@ -126,13 +126,13 @@ public class UserJourneyCookieServiceTests
         model.WhenWasQualificationAwarded.Should().Be(existingModel.WhenWasQualificationAwarded);
         model.WhereWasQualificationAwarded.Should().Be(existingModel.WhereWasQualificationAwarded);
     }
-    
+
     [TestMethod]
     public void GetUserJourneyModelFromCookie_CookieModelDoesntSerialize_SetsBaseModelAsCookie()
     {
         var mockHttpContextAccessor = SetHttpContextWithExistingCookie("test failure");
         var mockLogger = new Mock<ILogger<UserJourneyCookieService>>();
-        
+
         var service = new UserJourneyCookieService(mockHttpContextAccessor.Object, mockLogger.Object);
 
         var model = service.GetUserJourneyModelFromCookie();
@@ -150,19 +150,19 @@ public class UserJourneyCookieServiceTests
     {
         var mockHttpContextAccessor = SetHttpContextWithExistingCookie(null);
         var mockLogger = new Mock<ILogger<UserJourneyCookieService>>();
-        
+
         var service = new UserJourneyCookieService(mockHttpContextAccessor.Object, mockLogger.Object);
-        
+
         service.ResetUserJourneyCookie();
-        
+
         var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel());
         CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
     }
-    
+
     [TestMethod]
     public void ResetUserJourneyCookie_FullModelAsCookieExists_AddsBaseModelAsCookie()
     {
-        var model = new UserJourneyModel()
+        var model = new UserJourneyModel
                     {
                         LevelOfQualification = "test level of qualification",
                         WhenWasQualificationAwarded = "test when was qualification awarded",
@@ -170,11 +170,11 @@ public class UserJourneyCookieServiceTests
                     };
         var mockHttpContextAccessor = SetHttpContextWithExistingCookie(model);
         var mockLogger = new Mock<ILogger<UserJourneyCookieService>>();
-        
+
         var service = new UserJourneyCookieService(mockHttpContextAccessor.Object, mockLogger.Object);
-        
+
         service.ResetUserJourneyCookie();
-        
+
         var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel());
         CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
     }
@@ -200,8 +200,9 @@ public class UserJourneyCookieServiceTests
                        .Returns(responseCookiesMock.Object);
         return httpContextMock;
     }
-    
-    private static void CheckSerializedModelWasSet(Mock<IHttpContextAccessor> mockContext, string serializedModelToCheck)
+
+    private static void CheckSerializedModelWasSet(Mock<IHttpContextAccessor> mockContext,
+                                                   string serializedModelToCheck)
     {
         var in364Days = new DateTimeOffset(DateTime.Now.AddDays(364));
         var inOneYear = new DateTimeOffset(DateTime.Now.AddYears(1));

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/ViewComponents/FooterLinksViewComponentTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/ViewComponents/FooterLinksViewComponentTests.cs
@@ -22,7 +22,7 @@ public class FooterLinksViewComponentTests
                              { DisplayText = "Test", Href = "https://test.com", OpenInNewTab = true };
 
         mockContentService.Setup(x => x.GetNavigationLinks())
-                          .ReturnsAsync(new List<NavigationLink> { navigationLink });
+                          .ReturnsAsync([navigationLink]);
 
         var footerLinksViewComponent = new FooterLinksViewComponent(mockContentService.Object, mockLogger.Object);
         var result = await footerLinksViewComponent.InvokeAsync();
@@ -36,26 +36,6 @@ public class FooterLinksViewComponentTests
         data.Should().NotBeNull();
 
         data![0].DisplayText.Should().Be(navigationLink.DisplayText);
-    }
-
-    [TestMethod]
-    public async Task InvokeAsync_ContentServiceReturnsNull_ReturnsEmptyNavigationLinks()
-    {
-        var mockContentService = new Mock<IContentService>();
-        var mockLogger = new Mock<ILogger<FooterLinksViewComponent>>();
-
-        mockContentService.Setup(x => x.GetNavigationLinks()).ReturnsAsync((List<NavigationLink>?)default);
-
-        var footerLinksViewComponent = new FooterLinksViewComponent(mockContentService.Object, mockLogger.Object);
-        var result = await footerLinksViewComponent.InvokeAsync();
-
-        result.Should().NotBeNull();
-
-        var model = (result as ViewViewComponentResult)?.ViewData?.Model;
-        model.Should().NotBeNull().And.BeAssignableTo<IEnumerable<NavigationLink>>();
-
-        var data = ((IEnumerable<NavigationLink>)model!).ToList();
-        data.Should().BeEmpty();
     }
 
     [TestMethod]


### PR DESCRIPTION
# Description

Minor tidy up.

Avoiding null enumerable return in `GetNavigationLinks()` simplifies the code and makes one unit test redundant.

Make the method `GetAdvicePage` in the Mock service just return a null rather than throw a `NotImplementedException`, which breaks "L" of "SOLID". Preemptive strike in anticipation of SonarCloud!

Other minor tidy up such as formatting.

# How Has This Been Tested?

Tested locally, all unit tests pass. 

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules