### PR TITLE
chore/date-filtering

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
@@ -94,6 +94,7 @@ public class ContentfulContentFilterService(
             else if (qualificationStartDate is null
                      && qualificationEndDate is not null
                      // ReSharper disable once MergeSequentialChecks
+                     // ...reveals the intention more clearly this way
                      && enteredStartDate <= qualificationEndDate)
             {
                 // if qualification start date is null, check entered start date is <= ToWhichYear & add to results

--- a/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
@@ -18,7 +18,7 @@ public class ContentfulContentFilterService(
 
     private readonly ReadOnlyDictionary<string, int>
         _months = new(
-                      new Dictionary<string, int>
+                      new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase)
                       {
                           { "Jan", 1 },
                           { "Feb", 2 },

--- a/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
@@ -141,7 +141,7 @@ public class ContentfulContentFilterService(
         var splitQualificationDate = qualificationDate.Split('-');
         if (splitQualificationDate.Length != 2)
         {
-            logger.LogError("Found qualification date {QualificationDate} with unexpected format", qualificationDate);
+            logger.LogError("Qualification date {QualificationDate} has unexpected format", qualificationDate);
             return (false, 0, 0);
         }
 

--- a/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
@@ -16,23 +16,23 @@ public class ContentfulContentFilterService(
 {
     private const int Day = 28;
 
-    private readonly ReadOnlyDictionary<string, int>
-        _months = new(
-                      new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase)
-                      {
-                          { "Jan", 1 },
-                          { "Feb", 2 },
-                          { "Mar", 3 },
-                          { "Apr", 4 },
-                          { "May", 5 },
-                          { "Jun", 6 },
-                          { "Jul", 7 },
-                          { "Aug", 8 },
-                          { "Sep", 9 },
-                          { "Oct", 10 },
-                          { "Nov", 11 },
-                          { "Dec", 12 }
-                      });
+    private static readonly ReadOnlyDictionary<string, int>
+        Months = new(
+                     new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase)
+                     {
+                         { "Jan", 1 },
+                         { "Feb", 2 },
+                         { "Mar", 3 },
+                         { "Apr", 4 },
+                         { "May", 5 },
+                         { "Jun", 6 },
+                         { "Jul", 7 },
+                         { "Aug", 8 },
+                         { "Sep", 9 },
+                         { "Oct", 10 },
+                         { "Nov", 11 },
+                         { "Dec", 12 }
+                     });
 
     // Used by the unit tests to inject a mock builder that returns the query params
     public QueryBuilder<Qualification> QueryBuilder { get; init; } = QueryBuilder<Qualification>.New;
@@ -159,7 +159,7 @@ public class ContentfulContentFilterService(
             return (false, 0, 0);
         }
 
-        if (!_months.TryGetValue(abbreviatedMonth, out var month))
+        if (!Months.TryGetValue(abbreviatedMonth, out var month))
         {
             logger.LogError("Qualification date {QualificationDate} contains unexpected month value",
                             qualificationDate);

--- a/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/ContentfulContentFilterService.cs
@@ -1,5 +1,4 @@
 using System.Collections.ObjectModel;
-using System.Globalization;
 using Contentful.Core;
 using Contentful.Core.Models;
 using Contentful.Core.Search;
@@ -15,24 +14,23 @@ public class ContentfulContentFilterService(
     : IContentFilterService
 {
     private const int Day = 28;
-    private static readonly DateTimeFormatInfo CurrentFormatInfo = CultureInfo.CurrentCulture.DateTimeFormat;
 
-    private readonly ReadOnlyDictionary<int, string>
+    private readonly ReadOnlyDictionary<string, int>
         _months = new(
-                      new Dictionary<int, string>
+                      new Dictionary<string, int>
                       {
-                          { 1, CurrentFormatInfo.AbbreviatedMonthNames[0] },
-                          { 2, CurrentFormatInfo.AbbreviatedMonthNames[1] },
-                          { 3, CurrentFormatInfo.AbbreviatedMonthNames[2] },
-                          { 4, CurrentFormatInfo.AbbreviatedMonthNames[3] },
-                          { 5, CurrentFormatInfo.AbbreviatedMonthNames[4] },
-                          { 6, CurrentFormatInfo.AbbreviatedMonthNames[5] },
-                          { 7, CurrentFormatInfo.AbbreviatedMonthNames[6] },
-                          { 8, CurrentFormatInfo.AbbreviatedMonthNames[7] },
-                          { 9, CurrentFormatInfo.AbbreviatedMonthNames[8] },
-                          { 10, CurrentFormatInfo.AbbreviatedMonthNames[9] },
-                          { 11, CurrentFormatInfo.AbbreviatedMonthNames[10] },
-                          { 12, CurrentFormatInfo.AbbreviatedMonthNames[11] }
+                          { "Jan", 1 },
+                          { "Feb", 2 },
+                          { "Mar", 3 },
+                          { "Apr", 4 },
+                          { "May", 5 },
+                          { "Jun", 6 },
+                          { "Jul", 7 },
+                          { "Aug", 8 },
+                          { "Sep", 9 },
+                          { "Oct", 10 },
+                          { "Nov", 11 },
+                          { "Dec", 12 }
                       });
 
     // Used by the unit tests to inject a mock builder that returns the query params
@@ -94,6 +92,7 @@ public class ContentfulContentFilterService(
             }
             else if (qualificationStartDate is null
                      && qualificationEndDate is not null
+                     // ReSharper disable once MergeSequentialChecks
                      && enteredStartDate <= qualificationEndDate)
             {
                 // if qualification start date is null, check entered start date is <= ToWhichYear & add to results
@@ -127,7 +126,9 @@ public class ContentfulContentFilterService(
         var splitQualificationDate = qualificationDate.Split('-');
         if (splitQualificationDate.Length != 2) return null;
 
-        var month = _months.FirstOrDefault(x => x.Value == splitQualificationDate[0]).Key;
+        var abbreviatedMonth = splitQualificationDate[0];
+
+        var month = _months[abbreviatedMonth];
         var year = Convert.ToInt32(splitQualificationDate[1]) + 2000;
 
         return new DateOnly(year, month, Day);

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentFilterServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentFilterServiceTests.cs
@@ -286,6 +286,73 @@ public class ContentfulContentFilterServiceTests
     }
 
     [TestMethod]
+    public async Task GetFilteredQualifications_FilterOnDates_MonthIsCaseInsensitive_ReturnsFilteredQualifications()
+    {
+        var results = new ContentfulCollection<Qualification>
+                      {
+                          Items = new[]
+                                  {
+                                      new Qualification(
+                                                        "EYQ-123",
+                                                        "test",
+                                                        "NCFE",
+                                                        4,
+                                                        "Apr-15",
+                                                        "aug-19",
+                                                        "abc/123/987",
+                                                        "requirements"),
+                                      new Qualification(
+                                                        "EYQ-741",
+                                                        "test",
+                                                        "Pearson",
+                                                        4,
+                                                        null,
+                                                        "seP-19",
+                                                        "def/456/951",
+                                                        "requirements"),
+                                      new Qualification(
+                                                        "EYQ-746",
+                                                        "test",
+                                                        "CACHE",
+                                                        4,
+                                                        "sEp-15",
+                                                        null,
+                                                        "ghi/456/951",
+                                                        "requirements"),
+                                      new Qualification(
+                                                        "EYQ-752",
+                                                        "test",
+                                                        "CACHE",
+                                                        4,
+                                                        "SEP-21",
+                                                        null,
+                                                        "ghi/456/951",
+                                                        "requirements")
+                                  }
+                      };
+        var mockContentfulClient = new Mock<IContentfulClient>();
+        mockContentfulClient.Setup(x => x.GetEntries(
+                                                     It.IsAny<QueryBuilder<Qualification>>(),
+                                                     It.IsAny<CancellationToken>()))
+                            .ReturnsAsync(results);
+
+        var mockQueryBuilder = new MockQueryBuilder();
+        var mockLogger = new Mock<ILogger<ContentfulContentFilterService>>();
+        var filterService = new ContentfulContentFilterService(mockContentfulClient.Object, mockLogger.Object)
+                            {
+                                QueryBuilder = mockQueryBuilder
+                            };
+
+        var filteredQualifications = await filterService.GetFilteredQualifications(4, 5, 2016);
+
+        filteredQualifications.Should().NotBeNull();
+        filteredQualifications.Count.Should().Be(3);
+        filteredQualifications[0].QualificationId.Should().Be("EYQ-123");
+        filteredQualifications[1].QualificationId.Should().Be("EYQ-741");
+        filteredQualifications[2].QualificationId.Should().Be("EYQ-746");
+    }
+
+    [TestMethod]
     public async Task GetFilteredQualifications_ContentfulClientThrowsException_ReturnsEmptyList()
     {
         var mockContentfulClient = new Mock<IContentfulClient>();

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentFilterServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentFilterServiceTests.cs
@@ -382,7 +382,7 @@ public class ContentfulContentFilterServiceTests
                                                         "test",
                                                         "NCFE",
                                                         4,
-                                                        "Sept-15", // "Sept" in the data should be "Sep"
+                                                        "Sept-15", // "Sept" in the data: we expect "Sep"
                                                         "Aug-19",
                                                         "abc/123/987",
                                                         "requirements")
@@ -419,8 +419,8 @@ public class ContentfulContentFilterServiceTests
                                                         "test",
                                                         "NCFE",
                                                         4,
-                                                        "Sep-15", // "Sept" in the data should be "Sep"
-                                                        "Aug-1a",
+                                                        "Sep-15",
+                                                        "Aug-1a", // invalid year typo
                                                         "abc/123/987",
                                                         "requirements")
                                   }


### PR DESCRIPTION
# Description

Avoid using culture info for month abbreviations, as these
come from the data and do not originate with any culture info.

When filtering, if a qualification is encountered with a date
that does not conform to Mmm-yy (e.g. "Sep-15") then log an
error and do not attempt to convert it into a filterable date.

Make it a bit more lenient, by making the month part of filter
case-insensitive.

# How Has This Been Tested?

New unit tests for logging. Runs locally.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules