### PR TITLE
fix/month-validation

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
@@ -121,7 +121,7 @@ public class QuestionsController(
 
         userJourneyCookieService.SetLevelOfQualification(model.Option!);
 
-        if (model.Option == "2" && WithinDateRange())
+        if (model.Option == "2" && WasAwardedBetweenSeptember2014AndAugust2019())
         {
             return RedirectToAction("QualificationsStartedBetweenSept2014AndAug2019", "Advice");
         }
@@ -173,7 +173,7 @@ public class QuestionsController(
         return RedirectToAction("Get", "QualificationDetails");
     }
 
-    private bool WithinDateRange()
+    private bool WasAwardedBetweenSeptember2014AndAugust2019()
     {
         var (startDateMonth, startDateYear) = userJourneyCookieService.GetWhenWasQualificationAwarded();
         if (startDateMonth is not null && startDateYear is not null)
@@ -243,11 +243,13 @@ public class QuestionsController(
     {
         var awardingOrganisationExclusions =
             new[] { AwardingOrganisations.AllHigherEducation, AwardingOrganisations.Various };
-        var uniqueAwardingOrganisations = qualifications.Select(x => x.AwardingOrganisationTitle)
-                                                        .Distinct()
-                                                        .Where(x => !awardingOrganisationExclusions.Any(x.Contains))
-                                                        .Order()
-                                                        .ToList();
+
+        var uniqueAwardingOrganisations =
+            qualifications.Select(x => x.AwardingOrganisationTitle)
+                          .Distinct()
+                          .Where(x => !Array.Exists(awardingOrganisationExclusions, x.Contains))
+                          .Order()
+                          .ToList();
 
         model.ActionName = actionName;
         model.ControllerName = controllerName;

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/DateQuestionModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/DateQuestionModel.cs
@@ -13,14 +13,4 @@ public class DateQuestionModel : BaseQuestionModel
     [Required] public int SelectedMonth { get; init; }
 
     [Required] public int SelectedYear { get; init; }
-
-    public bool IsModelValid()
-    {
-        if (SelectedMonth is < 1 or > 12)
-        {
-            return false;
-        }
-
-        return SelectedYear > 1900 && SelectedYear <= DateTime.UtcNow.Year;
-    }
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/DateQuestionModelValidator.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/DateQuestionModelValidator.cs
@@ -1,0 +1,22 @@
+using Dfe.EarlyYearsQualification.Web.Services.DatesAndTimes;
+
+namespace Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
+
+public class DateQuestionModelValidator(IDateTimeAdapter dateTimeAdapter) : IDateQuestionModelValidator
+{
+    public bool IsValid(DateQuestionModel model)
+    {
+        if (model.SelectedYear < 1900
+            || model.SelectedMonth < 1
+            || model.SelectedMonth > 12)
+        {
+            return false;
+        }
+
+        var selectedDate = new DateOnly(model.SelectedYear, model.SelectedMonth, 1);
+
+        var now = dateTimeAdapter.Now();
+
+        return selectedDate <= DateOnly.FromDateTime(now);
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/IDateQuestionModelValidator.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/IDateQuestionModelValidator.cs
@@ -1,0 +1,6 @@
+namespace Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
+
+public interface IDateQuestionModelValidator
+{
+    bool IsValid(DateQuestionModel model);
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Program.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Program.cs
@@ -5,8 +5,10 @@ using Dfe.EarlyYearsQualification.Content.Extensions;
 using Dfe.EarlyYearsQualification.Content.Services;
 using Dfe.EarlyYearsQualification.Mock.Extensions;
 using Dfe.EarlyYearsQualification.Web.Filters;
+using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
 using Dfe.EarlyYearsQualification.Web.Security;
 using Dfe.EarlyYearsQualification.Web.Services.CookiesPreferenceService;
+using Dfe.EarlyYearsQualification.Web.Services.DatesAndTimes;
 using Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
 using GovUk.Frontend.AspNetCore;
 using Microsoft.AspNetCore.DataProtection;
@@ -65,6 +67,8 @@ builder.Services.AddScoped(x =>
                            });
 
 builder.Services.AddSingleton<IFuzzyAdapter, FuzzyAdapter>();
+builder.Services.AddSingleton<IDateTimeAdapter, DateTimeAdapter>();
+builder.Services.AddSingleton<IDateQuestionModelValidator, DateQuestionModelValidator>();
 
 var accessIsChallenged = !builder.Configuration.GetValue<bool>("ServiceAccess:IsPublic");
 // ...by default, challenge the user for the secret value unless that's explicitly turned off

--- a/src/Dfe.EarlyYearsQualification.Web/Services/DatesAndTimes/DateTimeAdapter.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/DatesAndTimes/DateTimeAdapter.cs
@@ -1,0 +1,9 @@
+namespace Dfe.EarlyYearsQualification.Web.Services.DatesAndTimes;
+
+public class DateTimeAdapter : IDateTimeAdapter
+{
+    public DateTime Now()
+    {
+        return DateTime.Now;
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Services/DatesAndTimes/IDateTimeAdapter.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/DatesAndTimes/IDateTimeAdapter.cs
@@ -1,0 +1,6 @@
+namespace Dfe.EarlyYearsQualification.Web.Services.DatesAndTimes;
+
+public interface IDateTimeAdapter
+{
+    DateTime Now();
+}

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -9,6 +9,7 @@ using Dfe.EarlyYearsQualification.Web.Constants;
 using Dfe.EarlyYearsQualification.Web.Controllers;
 using Dfe.EarlyYearsQualification.Web.Models;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
+using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
 using Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
@@ -28,12 +29,14 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         mockContentService.Setup(x => x.GetRadioQuestionPage(QuestionPages.WhereWasTheQualificationAwarded))
                           .ReturnsAsync((RadioQuestionPage?)default).Verifiable();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhereWasTheQualificationAwarded();
 
@@ -58,6 +61,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var questionPage = new RadioQuestionPage
                            {
@@ -69,7 +73,8 @@ public class QuestionsControllerTests
                           .ReturnsAsync(questionPage);
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhereWasTheQualificationAwarded();
 
@@ -97,9 +102,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         controller.ModelState.AddModelError("option", "test error");
         var result = await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel());
@@ -122,9 +129,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
@@ -149,9 +158,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel { Option = Options.England });
@@ -174,6 +185,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var questionPage = new DateQuestionPage
                            {
@@ -188,7 +200,8 @@ public class QuestionsControllerTests
                           .ReturnsAsync(questionPage);
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhenWasTheQualificationStarted();
 
@@ -219,12 +232,14 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         mockContentService.Setup(x => x.GetDateQuestionPage(QuestionPages.WhenWasTheQualificationStarted))
                           .ReturnsAsync((DateQuestionPage?)default).Verifiable();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhenWasTheQualificationStarted();
 
@@ -246,9 +261,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         controller.ModelState.AddModelError("option", "test error");
         var result = await controller.WhenWasTheQualificationStarted(new DateQuestionModel());
@@ -276,6 +293,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var questionPage = new DateQuestionPage
                            {
@@ -290,7 +308,8 @@ public class QuestionsControllerTests
                           .ReturnsAsync(questionPage);
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhenWasTheQualificationStarted(new DateQuestionModel
                                                                      {
@@ -323,6 +342,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var questionPage = new DateQuestionPage
                            {
@@ -337,7 +357,8 @@ public class QuestionsControllerTests
                           .ReturnsAsync(questionPage);
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhenWasTheQualificationStarted(new DateQuestionModel
                                                                      {
@@ -370,14 +391,23 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+
+        mockQuestionModelValidator
+            .Setup(x => x.IsValid(It.IsAny<DateQuestionModel>()))
+            .Returns(true);
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
+
+        const int selectedMonth = 12;
+        const int selectedYear = 2024;
 
         var result = await controller.WhenWasTheQualificationStarted(new DateQuestionModel
                                                                      {
-                                                                         SelectedMonth = 12,
-                                                                         SelectedYear = 2024
+                                                                         SelectedMonth = selectedMonth,
+                                                                         SelectedYear = selectedYear
                                                                      });
 
         result.Should().NotBeNull();
@@ -387,7 +417,9 @@ public class QuestionsControllerTests
 
         resultType!.ActionName.Should().Be("WhatLevelIsTheQualification");
 
-        mockUserJourneyCookieService.Verify(x => x.SetWhenWasQualificationAwarded("12/2024"), Times.Once);
+        mockUserJourneyCookieService
+            .Verify(x => x.SetWhenWasQualificationAwarded($"{selectedMonth}/{selectedYear}"),
+                    Times.Once);
     }
 
     [TestMethod]
@@ -398,12 +430,14 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         mockContentService.Setup(x => x.GetRadioQuestionPage(QuestionPages.WhatLevelIsTheQualification))
                           .ReturnsAsync((RadioQuestionPage?)default).Verifiable();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhatLevelIsTheQualification();
 
@@ -428,6 +462,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var questionPage = new RadioQuestionPage
                            {
@@ -443,7 +478,8 @@ public class QuestionsControllerTests
         mockRenderer.Setup(x => x.ToHtml(It.IsAny<Document>())).ReturnsAsync("Test html body");
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhatLevelIsTheQualification();
 
@@ -475,9 +511,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         controller.ModelState.AddModelError("option", "test error");
         var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel());
@@ -500,9 +538,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel
                                                                   {
@@ -527,11 +567,13 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         mockUserJourneyCookieService.Setup(x => x.GetWhenWasQualificationAwarded())
                                     .Returns((6, 2015));
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel
                                                                   {
@@ -555,12 +597,14 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         mockContentService.Setup(x => x.GetDropdownQuestionPage(QuestionPages.WhatIsTheAwardingOrganisation))
                           .ReturnsAsync((DropdownQuestionPage?)default).Verifiable();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation();
 
@@ -585,6 +629,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -605,12 +650,13 @@ public class QuestionsControllerTests
                                                     It.IsAny<int?>(),
                                                     It.IsAny<int?>(),
                                                     It.IsAny<int?>(),
-                                                    It.IsAny<string?>(), 
+                                                    It.IsAny<string?>(),
                                                     It.IsAny<string?>()))
             .ReturnsAsync([]);
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation();
 
@@ -642,6 +688,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -677,7 +724,8 @@ public class QuestionsControllerTests
             .ReturnsAsync(listOfQualifications);
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation();
 
@@ -711,6 +759,7 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -743,7 +792,8 @@ public class QuestionsControllerTests
             .ReturnsAsync(listOfQualifications);
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation();
 
@@ -770,9 +820,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -819,9 +871,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation(new DropdownQuestionModel
                                                                     {
@@ -848,9 +902,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -894,9 +950,11 @@ public class QuestionsControllerTests
         var mockRenderer = new Mock<IHtmlRenderer>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object);
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
 
         var questionPage = new DropdownQuestionPage
                            {

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/DateQuestionModelValidatorTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/DateQuestionModelValidatorTests.cs
@@ -1,0 +1,107 @@
+using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
+using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
+using Dfe.EarlyYearsQualification.Web.Services.DatesAndTimes;
+using FluentAssertions;
+using Moq;
+
+namespace Dfe.EarlyYearsQualification.UnitTests.Services;
+
+[TestClass]
+public class DateQuestionModelValidatorTests
+{
+    [TestMethod]
+    public void DateQuestionModelValidator_GivenDateInRecentPast_ValidatesTrue()
+    {
+        var dateTimeAdapter = new Mock<IDateTimeAdapter>();
+        dateTimeAdapter.Setup(d => d.Now()).Returns(new DateTime(2024, 7, 16, 13, 1, 12, DateTimeKind.Local));
+
+        var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
+
+        var model = new DateQuestionModel { SelectedMonth = 5, SelectedYear = 2023 };
+
+        validator.IsValid(model).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void DateQuestionModelValidator_GivenDateEarlierThisMonth_ValidatesTrue()
+    {
+        var thisYear = 2024;
+        var thisMonth = 7;
+
+        var dateTimeAdapter = new Mock<IDateTimeAdapter>();
+        dateTimeAdapter.Setup(d => d.Now())
+                       .Returns(new DateTime(thisYear, thisMonth, 16, 13, 1, 12, DateTimeKind.Local));
+
+        var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
+
+        var model = new DateQuestionModel { SelectedMonth = thisMonth, SelectedYear = thisYear };
+
+        validator.IsValid(model).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void DateQuestionModelValidator_GivenDateThisMonthOnFirstOfMonth_ValidatesTrue()
+    {
+        var thisYear = 2024;
+        var thisMonth = 7;
+
+        var dateTimeAdapter = new Mock<IDateTimeAdapter>();
+        dateTimeAdapter.Setup(d => d.Now())
+                       .Returns(new DateTime(thisYear, thisMonth, 1, 0, 0, 1, DateTimeKind.Local));
+
+        var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
+
+        var model = new DateQuestionModel { SelectedMonth = thisMonth, SelectedYear = thisYear };
+
+        validator.IsValid(model).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void DateQuestionModelValidator_GivenDateInFuture_ValidatesFalse()
+    {
+        var dateTimeAdapter = new Mock<IDateTimeAdapter>();
+        dateTimeAdapter.Setup(d => d.Now()).Returns(new DateTime(2022, 10, 10, 15, 32, 12, DateTimeKind.Local));
+
+        var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
+
+        var model = new DateQuestionModel { SelectedMonth = 5, SelectedYear = 2023 };
+
+        validator.IsValid(model).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void DateQuestionModelValidator_GivenDateBefore1900_ValidatesFalse()
+    {
+        var dateTimeAdapter = new Mock<IDateTimeAdapter>();
+
+        var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
+
+        var model = new DateQuestionModel { SelectedMonth = 12, SelectedYear = 1899 };
+
+        validator.IsValid(model).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void DateQuestionModelValidator_GivenMonthBefore1_ValidatesFalse()
+    {
+        var dateTimeAdapter = new Mock<IDateTimeAdapter>();
+
+        var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
+
+        var model = new DateQuestionModel { SelectedMonth = 0, SelectedYear = 2024 };
+
+        validator.IsValid(model).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void DateQuestionModelValidator_GivenMonthAfter12_ValidatesFalse()
+    {
+        var dateTimeAdapter = new Mock<IDateTimeAdapter>();
+
+        var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
+
+        var model = new DateQuestionModel { SelectedMonth = 13, SelectedYear = 2024 };
+
+        validator.IsValid(model).Should().BeFalse();
+    }
+}

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/DateQuestionModelValidatorTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/DateQuestionModelValidatorTests.cs
@@ -57,6 +57,23 @@ public class DateQuestionModelValidatorTests
     }
 
     [TestMethod]
+    public void DateQuestionModelValidator_GivenDateLaterThisYear_ValidatesFalse()
+    {
+        var thisYear = 2024;
+        var thisMonth = 7;
+
+        var dateTimeAdapter = new Mock<IDateTimeAdapter>();
+        dateTimeAdapter.Setup(d => d.Now())
+                       .Returns(new DateTime(thisYear, thisMonth, 1, 0, 0, 1, DateTimeKind.Local));
+
+        var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
+
+        var model = new DateQuestionModel { SelectedMonth = thisMonth + 1, SelectedYear = thisYear };
+
+        validator.IsValid(model).Should().BeFalse();
+    }
+
+    [TestMethod]
     public void DateQuestionModelValidator_GivenDateInFuture_ValidatesFalse()
     {
         var dateTimeAdapter = new Mock<IDateTimeAdapter>();


### PR DESCRIPTION
# Description

Fixes bug where date question page would accept later month in current year.
New service class responsible for validating DateQuestionModel.
New DateTimeAdapter to allow unit testing of validator.

## Ticket number (if applicable)

EYQB-460

# How Has This Been Tested?

All unit tests pass locally.
Site works fine run locally.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules