### PR TITLE
New Scotland, Wales and NI advice pages

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Content/Constants/AdvicePages.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Constants/AdvicePages.cs
@@ -11,4 +11,19 @@ public static class AdvicePages
     ///     Entry ID for the "Level 2 qualifications started between 1 September 2014 and 31 August 2019" advice page.
     /// </summary>
     public const string QualificationsStartedBetweenSept2014AndAug2019 = "5orvwKkqUUggkzP0rlAX23";
+
+    /// <summary>
+    ///     Entry ID for the "Qualifications achieved in Northern Ireland" advice page.
+    /// </summary>
+    public const string QualificationsAchievedInNorthernIreland = "6PQgouvhAqW3IPonOcTsex";
+
+    /// <summary>
+    ///     Entry ID for the "Qualifications achieved in Scotland" advice page.
+    /// </summary>
+    public const string QualificationsAchievedInScotland = "3deQYTynsM9iLnJ5fgFqk";
+        
+    /// <summary>
+    ///     Entry ID for the "Qualifications achieved in Northern Ireland" advice page.
+    /// </summary>
+    public const string QualificationsAchievedInWales = "1Xu4FPcZDxFb5yDCI6lLCj";
 }

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
@@ -38,6 +38,18 @@ public class MockContentfulService : IContentService
                        await
                            Task.FromResult(CreateAdvicePage("Level 2 qualifications started between 1 September 2014 and 31 August 2019",
                                                             body, "/questions/what-level-is-the-qualification")),
+                   
+                   AdvicePages.QualificationsAchievedInScotland =>
+                       await Task.FromResult(CreateAdvicePage("Qualifications achieved in Scotland",
+                                                              body, "/questions/where-was-the-qualification-awarded")),
+                   
+                   AdvicePages.QualificationsAchievedInWales =>
+                       await Task.FromResult(CreateAdvicePage("Qualifications achieved in Wales",
+                                                              body, "/questions/where-was-the-qualification-awarded")),
+                   
+                   AdvicePages.QualificationsAchievedInNorthernIreland =>
+                       await Task.FromResult(CreateAdvicePage("Qualifications achieved in Northern Ireland",
+                                                              body, "/questions/where-was-the-qualification-awarded")),
                    _ => null
                };
     }
@@ -316,6 +328,18 @@ public class MockContentfulService : IContentService
                           new()
                           {
                               Label = "England", Value = "england"
+                          },
+                          new()
+                          {
+                              Label = "Scotland", Value = "scotland"
+                          },
+                          new()
+                          {
+                              Label = "Wales", Value = "wales"
+                          },
+                          new()
+                          {
+                              Label = "Northern Ireland", Value = "northern-ireland"
                           },
                           new()
                           {

--- a/src/Dfe.EarlyYearsQualification.Web/Constants/Options.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Constants/Options.cs
@@ -18,12 +18,12 @@ public static class Options
     public const string Scotland = "scotland";
     
     /// <summary>
-    ///     Option for Scotland
+    ///     Option for Wales
     /// </summary>
     public const string Wales = "wales";
     
     /// <summary>
-    ///     Option for Scotland
+    ///     Option for Northern Ireland
     /// </summary>
     public const string NorthernIreland = "northern-ireland";
 

--- a/src/Dfe.EarlyYearsQualification.Web/Constants/Options.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Constants/Options.cs
@@ -13,9 +13,19 @@ public static class Options
     public const string England = "england";
 
     /// <summary>
-    ///     Option for Scotland, Wales and Northern Ireland.
+    ///     Option for Scotland
     /// </summary>
-    public const string ScotlandWalesNi = "scotland-wales-ni";
+    public const string Scotland = "scotland";
+    
+    /// <summary>
+    ///     Option for Scotland
+    /// </summary>
+    public const string Wales = "wales";
+    
+    /// <summary>
+    ///     Option for Scotland
+    /// </summary>
+    public const string NorthernIreland = "northern-ireland";
 
     /// <summary>
     ///     Option for Not Sure.

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/AdviceController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/AdviceController.cs
@@ -23,6 +23,24 @@ public class AdviceController(ILogger<AdviceController> logger, IContentService 
     {
         return await GetView(AdvicePages.QualificationsStartedBetweenSept2014AndAug2019);
     }
+    
+    [HttpGet("qualifications-achieved-in-northern-ireland")]
+    public async Task<IActionResult> QualificationsAchievedInNorthernIreland()
+    {
+        return await GetView(AdvicePages.QualificationsAchievedInNorthernIreland);
+    }
+    
+    [HttpGet("qualifications-achieved-in-scotland")]
+    public async Task<IActionResult> QualificationsAchievedInScotland()
+    {
+        return await GetView(AdvicePages.QualificationsAchievedInScotland);
+    }
+    
+    [HttpGet("qualifications-achieved-in-wales")]
+    public async Task<IActionResult> QualificationsAchievedInWales()
+    {
+        return await GetView(AdvicePages.QualificationsAchievedInWales);
+    }
 
     private async Task<IActionResult> GetView(string advicePageId)
     {

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
@@ -50,9 +50,16 @@ public class QuestionsController(
             return View("Radio", model);
         }
 
-        if (model.Option == Options.OutsideOfTheUnitedKingdom)
+        switch (model.Option)
         {
-            return RedirectToAction("QualificationOutsideTheUnitedKingdom", "Advice");
+            case Options.OutsideOfTheUnitedKingdom:
+                return RedirectToAction("QualificationOutsideTheUnitedKingdom", "Advice");
+            case Options.Scotland:
+                return RedirectToAction("QualificationsAchievedInScotland", "Advice");
+            case Options.Wales:
+                return RedirectToAction("QualificationsAchievedInWales", "Advice");
+            case Options.NorthernIreland:
+                return RedirectToAction("QualificationsAchievedInNorthernIreland", "Advice");
         }
 
         userJourneyCookieService.SetWhereWasQualificationAwarded(model.Option!);

--- a/tests/Dfe.EarlyYearsQualification.AccessibilityTests/.pa11yci-ubuntu.js
+++ b/tests/Dfe.EarlyYearsQualification.AccessibilityTests/.pa11yci-ubuntu.js
@@ -20,7 +20,10 @@ var config = {
         "http://localhost:5000/confirm-qualification/eyq-240",
         "http://localhost:5000/qualifications/qualification-details/eyq-240",
         "http://localhost:5000/advice/level-2-qualifications-started-between-1-sept-2014-and-31-aug-2019",
-        "http://localhost:5000/advice/qualification-outside-the-united-kingdom"
+        "http://localhost:5000/advice/qualification-outside-the-united-kingdom",
+        "http://localhost:5000/advice/qualifications-achieved-in-scotland",
+        "http://localhost:5000/advice/qualifications-achieved-in-wales",
+        "http://localhost:5000/advice/qualifications-achieved-in-northern-ireland"
     ]
 };
 

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/journey/journey-spec.cy.js
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/journey/journey-spec.cy.js
@@ -24,6 +24,60 @@ describe('A spec used to test the various routes through the journey', () => {
     })
   })
 
+  it("should redirect the user when they select qualification was awarded in Scotland", () => {
+    // home page
+    cy.get('.govuk-button--start').click();
+
+    // where-was-the-qualification-awarded page
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq('/questions/where-was-the-qualification-awarded');
+    })
+
+    cy.get('#scotland').click();
+    cy.get('button[id="question-submit"]').click();
+
+    // qualifications-achieved-in-scotland
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq('/advice/qualifications-achieved-in-scotland');
+    })
+  })
+
+  it("should redirect the user when they select qualification was awarded in Wales", () => {
+    // home page
+    cy.get('.govuk-button--start').click();
+
+    // where-was-the-qualification-awarded page
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq('/questions/where-was-the-qualification-awarded');
+    })
+
+    cy.get('#wales').click();
+    cy.get('button[id="question-submit"]').click();
+
+    // qualifications-achieved-in-wales
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq('/advice/qualifications-achieved-in-wales');
+    })
+  })
+
+  it("should redirect the user when they select qualification was awarded in Northern Ireland", () => {
+    // home page
+    cy.get('.govuk-button--start').click();
+
+    // where-was-the-qualification-awarded page
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq('/questions/where-was-the-qualification-awarded');
+    })
+
+    cy.get('#northern-ireland').click();
+    cy.get('button[id="question-submit"]').click();
+
+    // qualifications-achieved-in-scotland
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq('/advice/qualifications-achieved-in-northern-ireland');
+    })
+  })
+
   it("should redirect the user when they select qualification was awarded in England", () => {
     // home page
     cy.get('.govuk-button--start').click();

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/pages/advice-spec.cy.js
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/pages/advice-spec.cy.js
@@ -4,17 +4,38 @@ describe("A spec that tests advice pages", () => {
     })
 
     // Mock details found in Dfe.EarlyYearsQualification.Mock.Content.MockContentfulService.  
-    it("Checks the qualification details are on the page", () => {
+    it("Checks the Qualifications achieved outside the United Kingdom details are on the page", () => {
         cy.visit("/advice/qualification-outside-the-united-kingdom");
         
         cy.get("#advice-page-heading").should("contain.text", "Qualifications achieved outside the United Kingdom");
         cy.get("#advice-page-body").should("contain.text", "Test Advice Page Body");
     })
 
-    it("Checks the level 2 between 1 Sept 2014 and 31 Aug 2019 are on the page", () => {
+    it("Checks the level 2 between 1 Sept 2014 and 31 Aug 2019 details are on the page", () => {
         cy.visit("/advice/level-2-qualifications-started-between-1-sept-2014-and-31-aug-2019");
         
         cy.get("#advice-page-heading").should("contain.text", "Level 2 qualifications started between 1 September 2014 and 31 August 2019");
+        cy.get("#advice-page-body").should("contain.text", "Test Advice Page Body");
+    })
+
+    it("Checks the Qualifications achieved in Scotland details are on the page", () => {
+        cy.visit("/advice/qualifications-achieved-in-scotland");
+
+        cy.get("#advice-page-heading").should("contain.text", "Qualifications achieved in Scotland");
+        cy.get("#advice-page-body").should("contain.text", "Test Advice Page Body");
+    })
+
+    it("Checks the Qualifications achieved in Wales details are on the page", () => {
+        cy.visit("/advice/qualifications-achieved-in-wales");
+
+        cy.get("#advice-page-heading").should("contain.text", "Qualifications achieved in Wales");
+        cy.get("#advice-page-body").should("contain.text", "Test Advice Page Body");
+    })
+
+    it("Checks the Qualifications achieved in Northern Ireland details are on the page", () => {
+        cy.visit("/advice/qualifications-achieved-in-northern-ireland");
+
+        cy.get("#advice-page-heading").should("contain.text", "Qualifications achieved in Northern Ireland");
         cy.get("#advice-page-body").should("contain.text", "Test Advice Page Body");
     })
 })

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/shared/urls-to-check.js
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/shared/urls-to-check.js
@@ -26,5 +26,8 @@ export const pagesWithoutForms = [
   "/accessibility-statement",
   "/advice/qualification-outside-the-united-kingdom",
   "/advice/level-2-qualifications-started-between-1-sept-2014-and-31-aug-2019",
-  "/qualifications/qualification-details/EYQ-240"
+  "/qualifications/qualification-details/EYQ-240",
+  "/advice/qualifications-achieved-in-scotland",
+  "/advice/qualifications-achieved-in-wales",
+  "/advice/qualifications-achieved-in-northern-ireland",
 ]

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/AdviceControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/AdviceControllerTests.cs
@@ -130,4 +130,175 @@ public class AdviceControllerTests
 
         mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
     }
+
+    [TestMethod]
+    public async Task QualificationsAchievedInNorthernIreland_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
+    {
+        var mockLogger = new Mock<ILogger<AdviceController>>();
+        var mockContentService = new Mock<IContentService>();
+        var mockHtmlRenderer = new Mock<IHtmlRenderer>();
+
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+
+        mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInNorthernIreland))
+                          .ReturnsAsync((AdvicePage?)default).Verifiable();
+        
+        var result = await controller.QualificationsAchievedInNorthernIreland();
+
+        result.Should().NotBeNull();
+
+        var resultType = result as RedirectToActionResult;
+
+        resultType.Should().NotBeNull();
+
+        resultType!.ActionName.Should().Be("Index");
+        resultType.ControllerName.Should().Be("Error");
+
+        mockLogger.VerifyError("No content for the advice page");
+    }
+
+    [TestMethod]
+    public async Task QualificationsAchievedInNorthernIreland_ContentServiceReturnsAdvicePage_ReturnsAdvicePageModel()
+    {
+        var mockLogger = new Mock<ILogger<AdviceController>>();
+        var mockContentService = new Mock<IContentService>();
+        var mockHtmlRenderer = new Mock<IHtmlRenderer>();
+
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+
+        var advicePage = new AdvicePage { Heading = "Heading", Body = ContentfulContentHelper.Text("Test html body") };
+        mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInNorthernIreland))
+                          .ReturnsAsync(advicePage);
+
+        mockHtmlRenderer.Setup(x => x.ToHtml(It.IsAny<Document>())).ReturnsAsync("Test html body");
+
+        var result = await controller.QualificationsAchievedInNorthernIreland();
+
+        result.Should().NotBeNull();
+
+        var resultType = result as ViewResult;
+        resultType.Should().NotBeNull();
+
+        var model = resultType!.Model as AdvicePageModel;
+        model.Should().NotBeNull();
+
+        model!.Heading.Should().Be(advicePage.Heading);
+        model.BodyContent.Should().Be("Test html body");
+
+        mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
+    }
+    
+    [TestMethod]
+    public async Task QualificationsAchievedInScotland_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
+    {
+        var mockLogger = new Mock<ILogger<AdviceController>>();
+        var mockContentService = new Mock<IContentService>();
+        var mockHtmlRenderer = new Mock<IHtmlRenderer>();
+
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+
+        mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInScotland))
+                          .ReturnsAsync((AdvicePage?)default).Verifiable();
+        
+        var result = await controller.QualificationsAchievedInScotland();
+
+        result.Should().NotBeNull();
+
+        var resultType = result as RedirectToActionResult;
+
+        resultType.Should().NotBeNull();
+
+        resultType!.ActionName.Should().Be("Index");
+        resultType.ControllerName.Should().Be("Error");
+
+        mockLogger.VerifyError("No content for the advice page");
+    }
+
+    [TestMethod]
+    public async Task QualificationsAchievedInScotland_ContentServiceReturnsAdvicePage_ReturnsAdvicePageModel()
+    {
+        var mockLogger = new Mock<ILogger<AdviceController>>();
+        var mockContentService = new Mock<IContentService>();
+        var mockHtmlRenderer = new Mock<IHtmlRenderer>();
+
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+
+        var advicePage = new AdvicePage { Heading = "Heading", Body = ContentfulContentHelper.Text("Test html body") };
+        mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInScotland))
+                          .ReturnsAsync(advicePage);
+
+        mockHtmlRenderer.Setup(x => x.ToHtml(It.IsAny<Document>())).ReturnsAsync("Test html body");
+
+        var result = await controller.QualificationsAchievedInScotland();
+
+        result.Should().NotBeNull();
+
+        var resultType = result as ViewResult;
+        resultType.Should().NotBeNull();
+
+        var model = resultType!.Model as AdvicePageModel;
+        model.Should().NotBeNull();
+
+        model!.Heading.Should().Be(advicePage.Heading);
+        model.BodyContent.Should().Be("Test html body");
+
+        mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
+    }
+    
+    [TestMethod]
+    public async Task QualificationsAchievedInWales_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
+    {
+        var mockLogger = new Mock<ILogger<AdviceController>>();
+        var mockContentService = new Mock<IContentService>();
+        var mockHtmlRenderer = new Mock<IHtmlRenderer>();
+
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+
+        mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInWales))
+                          .ReturnsAsync((AdvicePage?)default).Verifiable();
+        
+        var result = await controller.QualificationsAchievedInWales();
+
+        result.Should().NotBeNull();
+
+        var resultType = result as RedirectToActionResult;
+
+        resultType.Should().NotBeNull();
+
+        resultType!.ActionName.Should().Be("Index");
+        resultType.ControllerName.Should().Be("Error");
+
+        mockLogger.VerifyError("No content for the advice page");
+    }
+
+    [TestMethod]
+    public async Task QualificationsAchievedInWales_ContentServiceReturnsAdvicePage_ReturnsAdvicePageModel()
+    {
+        var mockLogger = new Mock<ILogger<AdviceController>>();
+        var mockContentService = new Mock<IContentService>();
+        var mockHtmlRenderer = new Mock<IHtmlRenderer>();
+
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+
+        var advicePage = new AdvicePage { Heading = "Heading", Body = ContentfulContentHelper.Text("Test html body") };
+        mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInWales))
+                          .ReturnsAsync(advicePage);
+
+        mockHtmlRenderer.Setup(x => x.ToHtml(It.IsAny<Document>())).ReturnsAsync("Test html body");
+
+        var result = await controller.QualificationsAchievedInWales();
+
+        result.Should().NotBeNull();
+
+        var resultType = result as ViewResult;
+        resultType.Should().NotBeNull();
+
+        var model = resultType!.Model as AdvicePageModel;
+        model.Should().NotBeNull();
+
+        model!.Heading.Should().Be(advicePage.Heading);
+        model.BodyContent.Should().Be("Test html body");
+
+        mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
+    }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -149,6 +149,93 @@ public class QuestionsControllerTests
 
         mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(It.IsAny<string>()), Times.Never);
     }
+    
+    [TestMethod]
+    public async Task Post_WhereWasTheQualificationAwarded_PassInScotland_RedirectsToAdvicePage()
+    {
+        var mockLogger = new Mock<ILogger<QuestionsController>>();
+        var mockContentService = new Mock<IContentService>();
+        var mockRenderer = new Mock<IHtmlRenderer>();
+        var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
+        var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+
+        var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
+
+        var result =
+            await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
+                                                             { Option = Options.Scotland });
+
+        result.Should().NotBeNull();
+
+        var resultType = result as RedirectToActionResult;
+        resultType.Should().NotBeNull();
+
+        resultType!.ActionName.Should().Be("QualificationsAchievedInScotland");
+        resultType.ControllerName.Should().Be("Advice");
+
+        mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(It.IsAny<string>()), Times.Never);
+    }
+    
+    [TestMethod]
+    public async Task Post_WhereWasTheQualificationAwarded_PassInWales_RedirectsToAdvicePage()
+    {
+        var mockLogger = new Mock<ILogger<QuestionsController>>();
+        var mockContentService = new Mock<IContentService>();
+        var mockRenderer = new Mock<IHtmlRenderer>();
+        var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
+        var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+
+        var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
+
+        var result =
+            await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
+                                                             { Option = Options.Wales });
+
+        result.Should().NotBeNull();
+
+        var resultType = result as RedirectToActionResult;
+        resultType.Should().NotBeNull();
+
+        resultType!.ActionName.Should().Be("QualificationsAchievedInWales");
+        resultType.ControllerName.Should().Be("Advice");
+
+        mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(It.IsAny<string>()), Times.Never);
+    }
+    
+    [TestMethod]
+    public async Task Post_WhereWasTheQualificationAwarded_PassInNorthernIreland_RedirectsToAdvicePage()
+    {
+        var mockLogger = new Mock<ILogger<QuestionsController>>();
+        var mockContentService = new Mock<IContentService>();
+        var mockRenderer = new Mock<IHtmlRenderer>();
+        var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
+        var mockContentFilterService = new Mock<IContentFilterService>();
+        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+
+        var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
+                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
+                                                 mockQuestionModelValidator.Object);
+
+        var result =
+            await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
+                                                             { Option = Options.NorthernIreland });
+
+        result.Should().NotBeNull();
+
+        var resultType = result as RedirectToActionResult;
+        resultType.Should().NotBeNull();
+
+        resultType!.ActionName.Should().Be("QualificationsAchievedInNorthernIreland");
+        resultType.ControllerName.Should().Be("Advice");
+
+        mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(It.IsAny<string>()), Times.Never);
+    }
 
     [TestMethod]
     public async Task Post_WhereWasTheQualificationAwarded_PassInEngland_RedirectsToQualificationDetails()

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
@@ -140,11 +140,17 @@ public class MockContentfulServiceTests
         result.CtaButtonText.Should().NotBeNullOrEmpty();
         result.ErrorMessage.Should().NotBeNullOrEmpty();
         result.Options.Should().NotBeNullOrEmpty();
-        result.Options.Count.Should().Be(2);
+        result.Options.Count.Should().Be(5);
         result.Options[0].Label.Should().Be("England");
         result.Options[0].Value.Should().Be("england");
-        result.Options[1].Label.Should().Be("Outside the United Kingdom");
-        result.Options[1].Value.Should().Be("outside-uk");
+        result.Options[1].Label.Should().Be("Scotland");
+        result.Options[1].Value.Should().Be("scotland");
+        result.Options[2].Label.Should().Be("Wales");
+        result.Options[2].Value.Should().Be("wales");
+        result.Options[3].Label.Should().Be("Northern Ireland");
+        result.Options[3].Value.Should().Be("northern-ireland");
+        result.Options[4].Label.Should().Be("Outside the United Kingdom");
+        result.Options[4].Value.Should().Be("outside-uk");
     }
 
     [TestMethod]


### PR DESCRIPTION
# Description

- Added new Scotland, Wales and Northern Ireland static advice pages
- Hooked them up to the where qual was awarded page
- Added unit and E2E tests

## Ticket number (if applicable)

https://dfedigital.atlassian.net/browse/EYQB-369
https://dfedigital.atlassian.net/browse/EYQB-371
https://dfedigital.atlassian.net/browse/EYQB-372

# How Has This Been Tested?

- Tested manually locally, including back button navigation
- New and existing tests passing

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules