### PR TITLE
Updated to add in the reset functionality

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
@@ -27,6 +27,7 @@ public class QuestionsController(
     [HttpGet("where-was-the-qualification-awarded")]
     public async Task<IActionResult> WhereWasTheQualificationAwarded()
     {
+        userJourneyCookieService.ResetUserJourneyCookie();
         return await GetRadioView(QuestionPages.WhereWasTheQualificationAwarded,
                                   nameof(this.WhereWasTheQualificationAwarded),
                                   Questions);

--- a/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/UserJourneyCookieService.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/UserJourneyCookieService.cs
@@ -12,7 +12,7 @@ public class UserJourneyCookieService(IHttpContextAccessor context, ILogger<User
                                               {
                                                   Secure = true,
                                                   HttpOnly = true,
-                                                  Expires = new DateTimeOffset(DateTime.Now.AddYears(1))
+                                                  Expires = new DateTimeOffset(DateTime.Now.AddMinutes(30))
                                               };
 
     public void SetWhereWasQualificationAwarded(string location)

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -39,6 +39,8 @@ public class QuestionsControllerTests
                                                  mockQuestionModelValidator.Object);
 
         var result = await controller.WhereWasTheQualificationAwarded();
+        
+        mockUserJourneyCookieService.Verify(x => x.ResetUserJourneyCookie(), Times.Once);
 
         mockContentService.VerifyAll();
 
@@ -77,6 +79,8 @@ public class QuestionsControllerTests
                                                  mockQuestionModelValidator.Object);
 
         var result = await controller.WhereWasTheQualificationAwarded();
+        
+        mockUserJourneyCookieService.Verify(x => x.ResetUserJourneyCookie(), Times.Once);
 
         result.Should().NotBeNull();
 

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/UserJourneyCookieServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/UserJourneyCookieServiceTests.cs
@@ -414,8 +414,8 @@ public class UserJourneyCookieServiceTests
     private static void CheckSerializedModelWasSet(Mock<IHttpContextAccessor> mockContext,
                                                    string serializedModelToCheck)
     {
-        var in364Days = new DateTimeOffset(DateTime.Now.AddDays(364));
-        var inOneYear = new DateTimeOffset(DateTime.Now.AddYears(1));
+        var in29Minutes = new DateTimeOffset(DateTime.Now.AddMinutes(29));
+        var in30Minutes = new DateTimeOffset(DateTime.Now.AddMinutes(30));
 
         mockContext
             .Verify(http =>
@@ -425,8 +425,8 @@ public class UserJourneyCookieServiceTests
                                                                        options =>
                                                                            options.Secure
                                                                            && options.HttpOnly
-                                                                           && options.Expires > in364Days
-                                                                           && options.Expires < inOneYear)
+                                                                           && options.Expires > in29Minutes
+                                                                           && options.Expires < in30Minutes)
                                                                  ),
                     Times.Once);
     }


### PR DESCRIPTION
# Description

Updated to add in the reset functionality when someone starts the first step of the journey. Also, changed the length of the cookie to be 30 minutes.

## Ticket number (if applicable) - EYQB-400

# How Has This Been Tested?

Running locally and unit tests

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules