### PR TITLE
chore/location-options-rename

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Constants/QualificationAwardLocation.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Constants/QualificationAwardLocation.cs
@@ -1,6 +1,6 @@
 namespace Dfe.EarlyYearsQualification.Web.Constants;
 
-public static class Options
+public static class QualificationAwardLocation
 {
     /// <summary>
     ///     Option for outside the UK.

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
@@ -53,13 +53,13 @@ public class QuestionsController(
 
         switch (model.Option)
         {
-            case Options.OutsideOfTheUnitedKingdom:
+            case QualificationAwardLocation.OutsideOfTheUnitedKingdom:
                 return RedirectToAction("QualificationOutsideTheUnitedKingdom", "Advice");
-            case Options.Scotland:
+            case QualificationAwardLocation.Scotland:
                 return RedirectToAction("QualificationsAchievedInScotland", "Advice");
-            case Options.Wales:
+            case QualificationAwardLocation.Wales:
                 return RedirectToAction("QualificationsAchievedInWales", "Advice");
-            case Options.NorthernIreland:
+            case QualificationAwardLocation.NorthernIreland:
                 return RedirectToAction("QualificationsAchievedInNorthernIreland", "Advice");
         }
 

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -141,7 +141,7 @@ public class QuestionsControllerTests
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
-                                                             { Option = Options.OutsideOfTheUnitedKingdom });
+                                                             { Option = QualificationAwardLocation.OutsideOfTheUnitedKingdom });
 
         result.Should().NotBeNull();
 
@@ -170,7 +170,7 @@ public class QuestionsControllerTests
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
-                                                             { Option = Options.Scotland });
+                                                             { Option = QualificationAwardLocation.Scotland });
 
         result.Should().NotBeNull();
 
@@ -199,7 +199,7 @@ public class QuestionsControllerTests
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
-                                                             { Option = Options.Wales });
+                                                             { Option = QualificationAwardLocation.Wales });
 
         result.Should().NotBeNull();
 
@@ -228,7 +228,7 @@ public class QuestionsControllerTests
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
-                                                             { Option = Options.NorthernIreland });
+                                                             { Option = QualificationAwardLocation.NorthernIreland });
 
         result.Should().NotBeNull();
 
@@ -256,7 +256,7 @@ public class QuestionsControllerTests
                                                  mockQuestionModelValidator.Object);
 
         var result =
-            await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel { Option = Options.England });
+            await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel { Option = QualificationAwardLocation.England });
 
         result.Should().NotBeNull();
 
@@ -265,7 +265,7 @@ public class QuestionsControllerTests
 
         resultType!.ActionName.Should().Be("WhenWasTheQualificationStarted");
 
-        mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(Options.England), Times.Once);
+        mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(QualificationAwardLocation.England), Times.Once);
     }
 
     [TestMethod]


### PR DESCRIPTION
# Description

Suggesting that `Options` could have a less general name that better reveals what it's for.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules