### PR TITLE
Qualification classes use only mandatory fields in constructors.

### DIFF
--- a/content/Dfe.EarlyYearsQualification.ContentUpload/Program.cs
+++ b/content/Dfe.EarlyYearsQualification.ContentUpload/Program.cs
@@ -338,18 +338,23 @@ public static class Program
                 ratioRequirementsArray = ratioRequirementsString.Split(':');
             }
 
-            listObjResult.Add(new QualificationUpload(
-                                                      qualificationId,
-                                                      qualificationName,
-                                                      awardingOrganisationTitle,
-                                                      qualificationLevel,
-                                                      fromWhichYear,
-                                                      toWhichYear,
-                                                      qualificationNumber,
-                                                      additionalRequirements,
-                                                      additionalRequirementQuestionsArray,
-                                                      ratioRequirementsArray
-                                                     ));
+            var qualificationUpload =
+                new QualificationUpload(qualificationId,
+                                        qualificationName,
+                                        awardingOrganisationTitle,
+                                        qualificationLevel)
+                {
+                    FromWhichYear = fromWhichYear,
+                    ToWhichYear = toWhichYear,
+                    QualificationNumber = qualificationNumber,
+                    AdditionalRequirements =
+                        additionalRequirements,
+                    AdditionalRequirementQuestions =
+                        additionalRequirementQuestionsArray,
+                    RatioRequirements = ratioRequirementsArray
+                };
+
+            listObjResult.Add(qualificationUpload);
         }
 
         return listObjResult;

--- a/content/Dfe.EarlyYearsQualification.ContentUpload/QualificationUpload.cs
+++ b/content/Dfe.EarlyYearsQualification.ContentUpload/QualificationUpload.cs
@@ -4,13 +4,7 @@ public class QualificationUpload(
     string qualificationId,
     string qualificationName,
     string awardingOrganisationTitle,
-    int qualificationLevel,
-    string? fromWhichYear,
-    string? toWhichYear,
-    string? qualificationNumber,
-    string? additionalRequirements,
-    string[]? additionalRequirementQuestions,
-    string[]? ratioRequirements)
+    int qualificationLevel)
 {
     // Required Fields
     public string QualificationId { get; } = qualificationId;
@@ -19,12 +13,12 @@ public class QualificationUpload(
     public int QualificationLevel { get; } = qualificationLevel;
 
     // Optional Fields
-    public string? FromWhichYear { get; } = fromWhichYear;
-    public string? ToWhichYear { get; } = toWhichYear;
-    public string? QualificationNumber { get; } = qualificationNumber;
-    public string? AdditionalRequirements { get; } = additionalRequirements;
+    public string? FromWhichYear { get; init; }
+    public string? ToWhichYear { get; init; }
+    public string? QualificationNumber { get; init; }
+    public string? AdditionalRequirements { get; init; }
 
-    public string[]? AdditionalRequirementQuestions { get; } = additionalRequirementQuestions;
+    public string[]? AdditionalRequirementQuestions { get; init; }
 
-    public string[]? RatioRequirements { get; } = ratioRequirements;
+    public string[]? RatioRequirements { get; init; }
 }

--- a/src/Dfe.EarlyYearsQualification.Content/Entities/Qualification.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/Qualification.cs
@@ -1,42 +1,22 @@
 namespace Dfe.EarlyYearsQualification.Content.Entities;
 
-public class Qualification
+public class Qualification(
+    string qualificationId,
+    string qualificationName,
+    string awardingOrganisationTitle,
+    int qualificationLevel)
 {
-    public Qualification(
-        string qualificationId,
-        string qualificationName,
-        string awardingOrganisationTitle,
-        int qualificationLevel,
-        string? fromWhichYear,
-        string? toWhichYear,
-        string? qualificationNumber,
-        string? additionalRequirements,
-        List<AdditionalRequirementQuestion>? additionalRequirementQuestions,
-        List<RatioRequirement>? ratioRequirements)
-    {
-        QualificationId = qualificationId;
-        QualificationName = qualificationName;
-        AwardingOrganisationTitle = awardingOrganisationTitle;
-        QualificationLevel = qualificationLevel;
-        FromWhichYear = fromWhichYear;
-        ToWhichYear = toWhichYear;
-        QualificationNumber = qualificationNumber;
-        AdditionalRequirements = additionalRequirements;
-        AdditionalRequirementQuestions = additionalRequirementQuestions;
-        RatioRequirements = ratioRequirements;
-    }
-
     // Required Fields
-    public string QualificationId { get; }
-    public string QualificationName { get; }
-    public string AwardingOrganisationTitle { get; }
-    public int QualificationLevel { get; }
+    public string QualificationId { get; } = qualificationId;
+    public string QualificationName { get; } = qualificationName;
+    public string AwardingOrganisationTitle { get; } = awardingOrganisationTitle;
+    public int QualificationLevel { get; } = qualificationLevel;
 
     // Optional Fields
-    public string? FromWhichYear { get; }
-    public string? ToWhichYear { get; }
-    public string? QualificationNumber { get; }
-    public string? AdditionalRequirements { get; }
-    public List<AdditionalRequirementQuestion>? AdditionalRequirementQuestions { get; }
-    public List<RatioRequirement>? RatioRequirements { get; }
+    public string? FromWhichYear { get; init; }
+    public string? ToWhichYear { get; init; }
+    public string? QualificationNumber { get; init; }
+    public string? AdditionalRequirements { get; init; }
+    public List<AdditionalRequirementQuestion>? AdditionalRequirementQuestions { get; init; }
+    public List<RatioRequirement>? RatioRequirements { get; init; }
 }

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulFilterService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulFilterService.cs
@@ -41,12 +41,12 @@ public class MockContentfulFilterService : IContentFilterService
         return new Qualification(qualificationId,
                                  $"{qualificationId}-test",
                                  awardingOrganisation,
-                                 level,
-                                 startDate,
-                                 endDate,
-                                 "ghi/456/951",
-                                 "additional requirements",
-                                 null,
-                                 null);
+                                 level)
+               {
+                   FromWhichYear = startDate,
+                   ToWhichYear = endDate,
+                   QualificationNumber = "ghi/456/951",
+                   AdditionalRequirements = "additional requirements"
+               };
     }
 }

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
@@ -63,11 +63,10 @@ public class MockContentfulService : IContentService
                                                               body,
                                                               WhatLevelIsTheQualificationPath)),
 
-                   
                    AdvicePages.Level6QualificationPre2014 =>
                        await Task.FromResult(CreateAdvicePage("Level 6 qualification pre 2014",
                                                               body, WhatLevelIsTheQualificationPath)),
-                   
+
                    AdvicePages.Level6QualificationPost2014 =>
                        await Task.FromResult(CreateAdvicePage("Level 6 qualification post 2014",
                                                               body, WhatLevelIsTheQualificationPath)),
@@ -182,98 +181,105 @@ public class MockContentfulService : IContentService
 
     public async Task<Qualification?> GetQualificationById(string qualificationId)
     {
-        return await Task.FromResult(new Qualification(
-                                                       "EYQ-240",
+        return await Task.FromResult(new Qualification("EYQ-240",
                                                        "T Level Technical Qualification in Education and Childcare (Specialism - Early Years Educator)",
                                                        AwardingOrganisations.Ncfe,
-                                                       3,
-                                                       "2020",
-                                                       "2021",
-                                                       "603/5829/4",
-                                                       "The course must be assessed within the EYFS in an Early Years setting in England. Please note that the name of this qualification changed in February 2023. Qualifications achieved under either name are full and relevant provided that the start date for the qualification aligns with the date of the name change.",
-                                                       new List<AdditionalRequirementQuestion>
-                                                       {
-                                                           new()
-                                                           {
-                                                               Question = "Test question",
-                                                               HintText = "This is the hint text",
-                                                               DetailsHeading = "This is the details heading",
-                                                               DetailsContent =
-                                                                   ContentfulContentHelper
-                                                                       .Paragraph("This is the details content"),
-                                                               Answers =
-                                                               [
-                                                                   new Option
-                                                                   {
-                                                                       Label = "Yes",
-                                                                       Value = "yes"
-                                                                   },
+                                                       3)
+                                     {
+                                         FromWhichYear = "2020",
+                                         ToWhichYear = "2021",
+                                         QualificationNumber = "603/5829/4",
+                                         AdditionalRequirements =
+                                             "The course must be assessed within the EYFS in an Early Years setting in England. Please note that the name of this qualification changed in February 2023. Qualifications achieved under either name are full and relevant provided that the start date for the qualification aligns with the date of the name change.",
+                                         AdditionalRequirementQuestions =
+                                             new List<AdditionalRequirementQuestion>
+                                             {
+                                                 new()
+                                                 {
+                                                     Question = "Test question",
+                                                     HintText = "This is the hint text",
+                                                     DetailsHeading =
+                                                         "This is the details heading",
+                                                     DetailsContent =
+                                                         ContentfulContentHelper
+                                                             .Paragraph("This is the details content"),
+                                                     Answers =
+                                                     [
+                                                         new Option
+                                                         {
+                                                             Label = "Yes",
+                                                             Value = "yes"
+                                                         },
 
-                                                                   new Option
-                                                                   {
-                                                                       Label = "No",
-                                                                       Value = "no"
-                                                                   }
-                                                               ],
-                                                               ConfirmationStatement =
-                                                                   "This is the confirmation statement",
-                                                               AnswerToBeFullAndRelevant = true
-                                                           },
-                                                           new()
-                                                           {
-                                                               Question = "Test question 2",
-                                                               HintText = "This is the hint text",
-                                                               DetailsHeading = "This is the details heading",
-                                                               DetailsContent =
-                                                                   ContentfulContentHelper
-                                                                       .Paragraph("This is the details content"),
-                                                               Answers =
-                                                               [
-                                                                   new Option
-                                                                   {
-                                                                       Label = "Yes",
-                                                                       Value = "yes"
-                                                                   },
+                                                         new Option
+                                                         {
+                                                             Label = "No",
+                                                             Value = "no"
+                                                         }
+                                                     ],
+                                                     ConfirmationStatement =
+                                                         "This is the confirmation statement",
+                                                     AnswerToBeFullAndRelevant = true
+                                                 },
+                                                 new()
+                                                 {
+                                                     Question = "Test question 2",
+                                                     HintText = "This is the hint text",
+                                                     DetailsHeading =
+                                                         "This is the details heading",
+                                                     DetailsContent =
+                                                         ContentfulContentHelper
+                                                             .Paragraph("This is the details content"),
+                                                     Answers =
+                                                     [
+                                                         new Option
+                                                         {
+                                                             Label = "Yes",
+                                                             Value = "yes"
+                                                         },
 
-                                                                   new Option
-                                                                   {
-                                                                       Label = "No",
-                                                                       Value = "no"
-                                                                   }
-                                                               ],
-                                                               ConfirmationStatement =
-                                                                   "This is the confirmation statement",
-                                                               AnswerToBeFullAndRelevant = true
-                                                           }
-                                                       },
-                                                       new List<RatioRequirement>
-                                                       {
-                                                           new()
-                                                           {
-                                                               RatioRequirementName =
-                                                                   RatioRequirements.Level2RatioRequirementName,
-                                                               FullAndRelevantForLevel3After2014 = true
-                                                           },
-                                                           new()
-                                                           {
-                                                               RatioRequirementName =
-                                                                   RatioRequirements.Level3RatioRequirementName,
-                                                               FullAndRelevantForLevel3After2014 = true
-                                                           },
-                                                           new()
-                                                           {
-                                                               RatioRequirementName = RatioRequirements
-                                                                   .Level6RatioRequirementName
-                                                           },
-                                                           new()
-                                                           {
-                                                               RatioRequirementName =
-                                                                   RatioRequirements
-                                                                       .UnqualifiedRatioRequirementName,
-                                                               FullAndRelevantForLevel3After2014 = true
-                                                           }
-                                                       }
-                                                      ));
+                                                         new Option
+                                                         {
+                                                             Label = "No",
+                                                             Value = "no"
+                                                         }
+                                                     ],
+                                                     ConfirmationStatement =
+                                                         "This is the confirmation statement",
+                                                     AnswerToBeFullAndRelevant = true
+                                                 }
+                                             },
+                                         RatioRequirements =
+                                             new List<RatioRequirement>
+                                             {
+                                                 new()
+                                                 {
+                                                     RatioRequirementName =
+                                                         RatioRequirements
+                                                             .Level2RatioRequirementName,
+                                                     FullAndRelevantForLevel3After2014 = true
+                                                 },
+                                                 new()
+                                                 {
+                                                     RatioRequirementName =
+                                                         RatioRequirements
+                                                             .Level3RatioRequirementName,
+                                                     FullAndRelevantForLevel3After2014 = true
+                                                 },
+                                                 new()
+                                                 {
+                                                     RatioRequirementName = RatioRequirements
+                                                         .Level6RatioRequirementName
+                                                 },
+                                                 new()
+                                                 {
+                                                     RatioRequirementName =
+                                                         RatioRequirements
+                                                             .UnqualifiedRatioRequirementName,
+                                                     FullAndRelevantForLevel3After2014 = true
+                                                 }
+                                             }
+                                     });
     }
 
     public async Task<RadioQuestionPage?> GetRadioQuestionPage(string entryId)
@@ -313,20 +319,15 @@ public class MockContentfulService : IContentService
         return Task.FromResult(new List<Qualification>
                                {
                                    new("1", "TEST",
-                                       "A awarding organisation", 123, null,
-                                       null, null, null, null, null),
+                                       "A awarding organisation", 123),
                                    new("2", "TEST",
-                                       "B awarding organisation", 123, null,
-                                       null, null, null, null, null),
+                                       "B awarding organisation", 123),
                                    new("3", "TEST",
-                                       "C awarding organisation", 123, null,
-                                       null, null, null, null, null),
+                                       "C awarding organisation", 123),
                                    new("4", "TEST",
-                                       "D awarding organisation", 123, null,
-                                       null, null, null, null, null),
+                                       "D awarding organisation", 123),
                                    new("5", "TEST",
-                                       "E awarding organisation", 123, null,
-                                       null, null, null, null, null)
+                                       "E awarding organisation", 123)
                                });
     }
 
@@ -347,7 +348,8 @@ public class MockContentfulService : IContentService
                                          SearchCriteriaHeading = "Your search",
                                          MultipleQualificationsFoundText = "qualifications found",
                                          SingleQualificationFoundText = "qualification found",
-                                         PreSearchBoxContent = ContentfulContentHelper.Text("Pre search box content"),
+                                         PreSearchBoxContent =
+                                             ContentfulContentHelper.Text("Pre search box content"),
                                          PostQualificationListContent =
                                              ContentfulContentHelper.Link("Link to not on list advice page",
                                                                           "/advice/qualification-not-on-the-list"),

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/CheckAdditionalRequirementsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/CheckAdditionalRequirementsControllerTests.cs
@@ -24,7 +24,8 @@ public class CheckAdditionalRequirementsControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
 
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
         controller.ModelState.AddModelError("test", "error");
 
@@ -39,7 +40,7 @@ public class CheckAdditionalRequirementsControllerTests
 
         mockLogger.VerifyError("No qualificationId passed in");
     }
-    
+
     [TestMethod]
     public async Task Index_UnableToFindQualification_RedirectsToErrorPage()
     {
@@ -49,8 +50,9 @@ public class CheckAdditionalRequirementsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
 
         mockContentService.Setup(x => x.GetQualificationById("Test-123")).ReturnsAsync(value: null).Verifiable();
-        
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
 
         var result = await controller.Index("Test-123");
@@ -61,11 +63,11 @@ public class CheckAdditionalRequirementsControllerTests
         resultType.Should().NotBeNull();
         resultType!.ActionName.Should().Be("Index");
         resultType.ControllerName.Should().Be("Error");
-        
+
         mockContentService.VerifyAll();
         mockLogger.VerifyError("Could not find details for qualification with ID: Test-123");
     }
-    
+
     [TestMethod]
     public async Task Index_QualificationHasNullAdditionalRequirements_RedirectsToQualificationDetailsPage()
     {
@@ -75,8 +77,9 @@ public class CheckAdditionalRequirementsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
 
         mockContentService.Setup(x => x.GetQualificationById("Test-123")).ReturnsAsync(CreateQualification(null));
-        
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
 
         var result = await controller.Index("Test-123");
@@ -88,7 +91,7 @@ public class CheckAdditionalRequirementsControllerTests
         resultType!.ActionName.Should().Be("Index");
         resultType.ControllerName.Should().Be("QualificationDetails");
     }
-    
+
     [TestMethod]
     public async Task Index_PageContentIsNull_RedirectsToErrorPage()
     {
@@ -96,11 +99,13 @@ public class CheckAdditionalRequirementsControllerTests
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
         var mockContentService = new Mock<IContentService>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
-        
-        mockContentService.Setup(x => x.GetQualificationById("Test-123")).ReturnsAsync(CreateQualification(CreateAdditionalRequirementQuestions()));
+
+        mockContentService.Setup(x => x.GetQualificationById("Test-123"))
+                          .ReturnsAsync(CreateQualification(CreateAdditionalRequirementQuestions()));
         mockContentService.Setup(x => x.GetCheckAdditionalRequirementsPage()).ReturnsAsync(value: null);
-        
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
 
         var result = await controller.Index("Test-123");
@@ -111,11 +116,11 @@ public class CheckAdditionalRequirementsControllerTests
         resultType.Should().NotBeNull();
         resultType!.ActionName.Should().Be("Index");
         resultType.ControllerName.Should().Be("Error");
-        
+
         mockContentService.VerifyAll();
         mockLogger.VerifyError("No content for the check additional requirements page");
     }
-    
+
     [TestMethod]
     public async Task Index_PageContentIsReturned_MapsModelAndReturnsView()
     {
@@ -128,8 +133,9 @@ public class CheckAdditionalRequirementsControllerTests
         var pageContent = CreatePageContent();
         mockContentService.Setup(x => x.GetQualificationById("Test-123")).ReturnsAsync(qualification);
         mockContentService.Setup(x => x.GetCheckAdditionalRequirementsPage()).ReturnsAsync(pageContent);
-        
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
 
         var result = await controller.Index("Test-123");
@@ -142,7 +148,7 @@ public class CheckAdditionalRequirementsControllerTests
 
         resultType.Model.Should().NotBeNull();
         resultType.Model.Should().BeAssignableTo<CheckAdditionalRequirementsPageModel>();
-        
+
         var model = resultType.Model as CheckAdditionalRequirementsPageModel;
         model!.Heading.Should().BeSameAs(pageContent.Heading);
         model.AwardingOrganisationLabel.Should().BeSameAs(pageContent.AwardingOrganisationLabel);
@@ -176,10 +182,11 @@ public class CheckAdditionalRequirementsControllerTests
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
         var mockContentService = new Mock<IContentService>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
-        
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
-        
+
         var result = await controller.Post(new CheckAdditionalRequirementsPageModel { QualificationId = "Test-123" });
         result.Should().NotBeNull();
 
@@ -188,9 +195,10 @@ public class CheckAdditionalRequirementsControllerTests
         resultType!.ActionName.Should().Be("Index");
         resultType.ControllerName.Should().Be("QualificationDetails");
         resultType.RouteValues.Should().ContainSingle("qualificationId", "Test-123");
-        mockUserJourneyCookieService.Verify(x => x.SetAdditionalQuestionsAnswers(It.IsAny<Dictionary<string,string>>()), Times.Once);
+        mockUserJourneyCookieService
+            .Verify(x => x.SetAdditionalQuestionsAnswers(It.IsAny<Dictionary<string, string>>()), Times.Once);
     }
-    
+
     [TestMethod]
     public async Task Post_UnableToFindQualification_RedirectsToErrorPage()
     {
@@ -200,8 +208,9 @@ public class CheckAdditionalRequirementsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
 
         mockContentService.Setup(x => x.GetQualificationById("Test-123")).ReturnsAsync(value: null).Verifiable();
-        
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
 
         controller.ModelState.AddModelError("test", "test");
@@ -213,11 +222,11 @@ public class CheckAdditionalRequirementsControllerTests
         resultType.Should().NotBeNull();
         resultType!.ActionName.Should().Be("Index");
         resultType.ControllerName.Should().Be("Error");
-        
+
         mockContentService.VerifyAll();
         mockLogger.VerifyError("Could not find details for qualification with ID: Test-123");
     }
-    
+
     [TestMethod]
     public async Task Post_QualificationHasNullAdditionalRequirements_RedirectsToQualificationDetailsPage()
     {
@@ -227,8 +236,9 @@ public class CheckAdditionalRequirementsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
 
         mockContentService.Setup(x => x.GetQualificationById("Test-123")).ReturnsAsync(CreateQualification(null));
-        
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
 
         controller.ModelState.AddModelError("test", "test");
@@ -241,7 +251,7 @@ public class CheckAdditionalRequirementsControllerTests
         resultType!.ActionName.Should().Be("Index");
         resultType.ControllerName.Should().Be("QualificationDetails");
     }
-    
+
     [TestMethod]
     public async Task Post_PageContentIsNull_RedirectsToErrorPage()
     {
@@ -249,11 +259,13 @@ public class CheckAdditionalRequirementsControllerTests
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
         var mockContentService = new Mock<IContentService>();
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
-        
-        mockContentService.Setup(x => x.GetQualificationById("Test-123")).ReturnsAsync(CreateQualification(CreateAdditionalRequirementQuestions()));
+
+        mockContentService.Setup(x => x.GetQualificationById("Test-123"))
+                          .ReturnsAsync(CreateQualification(CreateAdditionalRequirementQuestions()));
         mockContentService.Setup(x => x.GetCheckAdditionalRequirementsPage()).ReturnsAsync(value: null);
-        
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
 
         controller.ModelState.AddModelError("test", "test");
@@ -265,11 +277,11 @@ public class CheckAdditionalRequirementsControllerTests
         resultType.Should().NotBeNull();
         resultType!.ActionName.Should().Be("Index");
         resultType.ControllerName.Should().Be("Error");
-        
+
         mockContentService.VerifyAll();
         mockLogger.VerifyError("No content for the check additional requirements page");
     }
-    
+
     [TestMethod]
     public async Task Post_PageContentIsReturned_MapsModelAndReturnsView()
     {
@@ -282,13 +294,15 @@ public class CheckAdditionalRequirementsControllerTests
         var pageContent = CreatePageContent();
         mockContentService.Setup(x => x.GetQualificationById("Test-123")).ReturnsAsync(qualification);
         mockContentService.Setup(x => x.GetCheckAdditionalRequirementsPage()).ReturnsAsync(pageContent);
-        
-        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+
+        var controller = new CheckAdditionalRequirementsController(mockLogger.Object, mockContentService.Object,
+                                                                   mockHtmlRenderer.Object,
                                                                    mockUserJourneyCookieService.Object);
 
         controller.ModelState.AddModelError("test", "test");
-        var answers = new Dictionary<string, string>();
-        answers.Add("Test question", "yes");
+
+        var answers = new Dictionary<string, string> { { "Test question", "yes" } };
+
         var result = await controller.Post(new CheckAdditionalRequirementsPageModel
                                            { QualificationId = "Test-123", Answers = answers });
 
@@ -300,7 +314,7 @@ public class CheckAdditionalRequirementsControllerTests
 
         resultType.Model.Should().NotBeNull();
         resultType.Model.Should().BeAssignableTo<CheckAdditionalRequirementsPageModel>();
-        
+
         var model = resultType.Model as CheckAdditionalRequirementsPageModel;
         model!.Heading.Should().BeSameAs(pageContent.Heading);
         model.AwardingOrganisationLabel.Should().BeSameAs(pageContent.AwardingOrganisationLabel);
@@ -327,11 +341,19 @@ public class CheckAdditionalRequirementsControllerTests
         model.HasErrors.Should().BeTrue();
     }
 
-    private static Qualification CreateQualification(List<AdditionalRequirementQuestion>? additionalRequirementQuestions)
+    private static Qualification CreateQualification(
+        List<AdditionalRequirementQuestion>? additionalRequirementQuestions)
     {
-        return new Qualification("Test-123", "Test name", "Awarding Org",
-                                 3, "Aug-14", null, "ABC/123/789", "Additional requirements",
-                                 additionalRequirementQuestions, new List<RatioRequirement>());
+        return new Qualification("Test-123",
+                                 "Test name",
+                                 "Awarding Org",
+                                 3)
+               {
+                   FromWhichYear = "Aug-14", QualificationNumber = "ABC/123/789",
+                   ToWhichYear = "Additional requirements",
+                   AdditionalRequirementQuestions = additionalRequirementQuestions,
+                   RatioRequirements = new List<RatioRequirement>()
+               };
     }
 
     private static List<AdditionalRequirementQuestion> CreateAdditionalRequirementQuestions()

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/ConfirmQualificationControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/ConfirmQualificationControllerTests.cs
@@ -146,9 +146,17 @@ public class ConfirmQualificationControllerTests
                 ErrorBannerLink = "Test error banner link"
             });
 
-        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(new Qualification("Some ID",
-         "Qualification Name", AwardingOrganisations.Ncfe, 2, "2014", "2019",
-         "ABC/547/900", "additional requirements", null, null));
+        var qualification = new Qualification("Some ID",
+                                              "Qualification Name",
+                                              AwardingOrganisations.Ncfe,
+                                              2)
+                            {
+                                FromWhichYear = "2014", ToWhichYear = "2019",
+                                QualificationNumber = "ABC/547/900",
+                                AdditionalRequirements = "additional requirements"
+                            };
+
+        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(qualification);
 
         var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
 
@@ -206,9 +214,17 @@ public class ConfirmQualificationControllerTests
         var mockContentService = new Mock<IContentService>();
 
         mockContentService.Setup(x => x.GetConfirmQualificationPage()).ReturnsAsync(default(ConfirmQualificationPage?));
-        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(new Qualification("Some ID",
-         "Qualification Name", AwardingOrganisations.Ncfe, 2, "2014", "2019",
-         "ABC/547/900", "additional requirements", null, null));
+
+        var qualification = new Qualification("Some ID",
+                                              "Qualification Name",
+                                              AwardingOrganisations.Ncfe,
+                                              2)
+                            {
+                                FromWhichYear = "2014", ToWhichYear = "2019",
+                                QualificationNumber = "ABC/547/900",
+                                AdditionalRequirements = "additional requirements"
+                            };
+        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(qualification);
 
         var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
 
@@ -312,9 +328,16 @@ public class ConfirmQualificationControllerTests
                 ErrorBannerLink = "Test error banner link"
             });
 
-        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(new Qualification("Some ID",
-         "Qualification Name", AwardingOrganisations.Ncfe, 2, "2014", "2019",
-         "ABC/547/900", "additional requirements", null, null));
+        var qualification = new Qualification("Some ID",
+                                              "Qualification Name",
+                                              AwardingOrganisations.Ncfe,
+                                              2)
+                            {
+                                FromWhichYear = "2014", ToWhichYear = "2019",
+                                QualificationNumber = "ABC/547/900",
+                                AdditionalRequirements = "additional requirements"
+                            };
+        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(qualification);
 
         var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
 
@@ -377,9 +400,18 @@ public class ConfirmQualificationControllerTests
         var mockLogger = new Mock<ILogger<ConfirmQualificationController>>();
         var mockContentService = new Mock<IContentService>();
         var additionalRequirements = new List<AdditionalRequirementQuestion> { new() };
-        mockContentService.Setup(x => x.GetQualificationById("TEST-123")).ReturnsAsync(new Qualification("Some ID",
-         "Qualification Name", AwardingOrganisations.Ncfe, 2, "2014", "2019",
-         "ABC/547/900", "additional requirements", additionalRequirements, null));
+
+        var qualification = new Qualification("Some ID",
+                                              "Qualification Name",
+                                              AwardingOrganisations.Ncfe,
+                                              2)
+                            {
+                                FromWhichYear = "2014", ToWhichYear = "2019",
+                                QualificationNumber = "ABC/547/900",
+                                AdditionalRequirements = "additional requirements",
+                                AdditionalRequirementQuestions = additionalRequirements
+                            };
+        mockContentService.Setup(x => x.GetQualificationById("TEST-123")).ReturnsAsync(qualification);
 
         var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
 
@@ -403,9 +435,17 @@ public class ConfirmQualificationControllerTests
     {
         var mockLogger = new Mock<ILogger<ConfirmQualificationController>>();
         var mockContentService = new Mock<IContentService>();
-        mockContentService.Setup(x => x.GetQualificationById("TEST-123")).ReturnsAsync(new Qualification("Some ID",
-         "Qualification Name", AwardingOrganisations.Ncfe, 2, "2014", "2019",
-         "ABC/547/900", "additional requirements", null, null));
+
+        var qualification = new Qualification("Some ID",
+                                              "Qualification Name",
+                                              AwardingOrganisations.Ncfe,
+                                              2)
+                            {
+                                FromWhichYear = "2014", ToWhichYear = "2019",
+                                QualificationNumber = "ABC/547/900",
+                                AdditionalRequirements = "additional requirements"
+                            };
+        mockContentService.Setup(x => x.GetQualificationById("TEST-123")).ReturnsAsync(qualification);
 
         var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
 
@@ -429,9 +469,17 @@ public class ConfirmQualificationControllerTests
     {
         var mockLogger = new Mock<ILogger<ConfirmQualificationController>>();
         var mockContentService = new Mock<IContentService>();
-        mockContentService.Setup(x => x.GetQualificationById("TEST-123")).ReturnsAsync(new Qualification("Some ID",
-         "Qualification Name", AwardingOrganisations.Ncfe, 2, "2014", "2019",
-         "ABC/547/900", "additional requirements", null, null));
+
+        var qualification = new Qualification("Some ID",
+                                              "Qualification Name",
+                                              AwardingOrganisations.Ncfe,
+                                              2)
+                            {
+                                FromWhichYear = "2014", ToWhichYear = "2019",
+                                QualificationNumber = "ABC/547/900",
+                                AdditionalRequirements = "additional requirements"
+                            };
+        mockContentService.Setup(x => x.GetQualificationById("TEST-123")).ReturnsAsync(qualification);
 
         var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
 

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QualificationDetailsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QualificationDetailsControllerTests.cs
@@ -133,9 +133,15 @@ public class QualificationDetailsControllerTests
 
         const string qualificationId = "eyq-145";
 
-        var qualificationResult = new Qualification(qualificationId, "Qualification Name", AwardingOrganisations.Ncfe,
-                                                    2, "2014", "2019",
-                                                    "ABC/547/900", "additional requirements", null, null);
+        var qualificationResult = new Qualification(qualificationId,
+                                                    "Qualification Name",
+                                                    AwardingOrganisations.Ncfe,
+                                                    2)
+                                  {
+                                      FromWhichYear = "2014", ToWhichYear = "2019",
+                                      QualificationNumber = "ABC/547/900",
+                                      AdditionalRequirements = "additional requirements"
+                                  };
         mockContentService.Setup(x => x.GetQualificationById(qualificationId)).ReturnsAsync(qualificationResult);
         mockContentService.Setup(x => x.GetDetailsPage()).ReturnsAsync(new DetailsPage());
 
@@ -183,10 +189,16 @@ public class QualificationDetailsControllerTests
         // Mismatch between the two lists here to simulate questions not being answered
         var listOfAdditionalReqsAnswered = new Dictionary<string, string>();
 
-        var qualificationResult = new Qualification(qualificationId, "Qualification Name", AwardingOrganisations.Ncfe,
-                                                    2, "2014", "2019",
-                                                    "ABC/547/900", "additional requirements", listOfAdditionalReqs,
-                                                    null);
+        var qualificationResult = new Qualification(qualificationId,
+                                                    "Qualification Name",
+                                                    AwardingOrganisations.Ncfe,
+                                                    2)
+                                  {
+                                      FromWhichYear = "2014", ToWhichYear = "2019",
+                                      QualificationNumber = "ABC/547/900",
+                                      AdditionalRequirements = "additional requirements",
+                                      AdditionalRequirementQuestions = listOfAdditionalReqs
+                                  };
 
         mockContentService.Setup(x => x.GetQualificationById(qualificationId)).ReturnsAsync(qualificationResult);
         mockContentService.Setup(x => x.GetDetailsPage()).ReturnsAsync(new DetailsPage());
@@ -253,10 +265,16 @@ public class QualificationDetailsControllerTests
                                                { "Another Question", answer2 }
                                            };
 
-        var qualificationResult = new Qualification(qualificationId, "Qualification Name", AwardingOrganisations.Ncfe,
-                                                    2, "2014", "2019",
-                                                    "ABC/547/900", "additional requirements", listOfAdditionalReqs,
-                                                    null);
+        var qualificationResult = new Qualification(qualificationId,
+                                                    "Qualification Name",
+                                                    AwardingOrganisations.Ncfe,
+                                                    2)
+                                  {
+                                      FromWhichYear = "2014", ToWhichYear = "2019",
+                                      QualificationNumber = "ABC/547/900",
+                                      AdditionalRequirements = "additional requirements",
+                                      AdditionalRequirementQuestions = listOfAdditionalReqs
+                                  };
 
         mockContentService.Setup(x => x.GetQualificationById(qualificationId)).ReturnsAsync(qualificationResult);
         mockContentService.Setup(x => x.GetDetailsPage()).ReturnsAsync(new DetailsPage());
@@ -317,9 +335,16 @@ public class QualificationDetailsControllerTests
 
         var ratioRequirements = new List<RatioRequirement>();
 
-        var qualificationResult = new Qualification(qualificationId, "Qualification Name", AwardingOrganisations.Ncfe,
-                                                    level, "2014", "2019",
-                                                    "ABC/547/900", "additional requirements", null, ratioRequirements);
+        var qualificationResult = new Qualification(qualificationId,
+                                                    "Qualification Name",
+                                                    AwardingOrganisations.Ncfe,
+                                                    level)
+                                  {
+                                      FromWhichYear = "2014", ToWhichYear = "2019",
+                                      QualificationNumber = "ABC/547/900",
+                                      AdditionalRequirements = "additional requirements",
+                                      RatioRequirements = ratioRequirements
+                                  };
 
         mockContentService.Setup(x => x.GetQualificationById(qualificationId)).ReturnsAsync(qualificationResult);
         mockContentService.Setup(x => x.GetDetailsPage()).ReturnsAsync(new DetailsPage());
@@ -364,9 +389,16 @@ public class QualificationDetailsControllerTests
                                     }
                                 };
 
-        var qualificationResult = new Qualification(qualificationId, "Qualification Name", AwardingOrganisations.Ncfe,
-                                                    level, "2014", "2019",
-                                                    "ABC/547/900", "additional requirements", null, ratioRequirements);
+        var qualificationResult = new Qualification(qualificationId,
+                                                    "Qualification Name",
+                                                    AwardingOrganisations.Ncfe,
+                                                    level)
+                                  {
+                                      FromWhichYear = "2014", ToWhichYear = "2019",
+                                      QualificationNumber = "ABC/547/900",
+                                      AdditionalRequirements = "additional requirements",
+                                      RatioRequirements = ratioRequirements
+                                  };
 
         mockContentService.Setup(x => x.GetQualificationById(qualificationId)).ReturnsAsync(qualificationResult);
         mockContentService.Setup(x => x.GetDetailsPage()).ReturnsAsync(new DetailsPage());
@@ -416,9 +448,16 @@ public class QualificationDetailsControllerTests
                                     }
                                 };
 
-        var qualificationResult = new Qualification(qualificationId, "Qualification Name", AwardingOrganisations.Ncfe,
-                                                    level, "2014", "2019",
-                                                    "ABC/547/900", "additional requirements", null, ratioRequirements);
+        var qualificationResult = new Qualification(qualificationId,
+                                                    "Qualification Name",
+                                                    AwardingOrganisations.Ncfe,
+                                                    level)
+                                  {
+                                      FromWhichYear = "2014", ToWhichYear = "2019",
+                                      QualificationNumber = "ABC/547/900",
+                                      AdditionalRequirements = "additional requirements",
+                                      RatioRequirements = ratioRequirements
+                                  };
 
         mockContentService.Setup(x => x.GetQualificationById(qualificationId)).ReturnsAsync(qualificationResult);
         mockContentService.Setup(x => x.GetDetailsPage()).ReturnsAsync(new DetailsPage());
@@ -482,9 +521,16 @@ public class QualificationDetailsControllerTests
                                     }
                                 };
 
-        var qualificationResult = new Qualification(qualificationId, "Qualification Name", AwardingOrganisations.Ncfe,
-                                                    level, "2014", "2019",
-                                                    "ABC/547/900", "additional requirements", null, ratioRequirements);
+        var qualificationResult = new Qualification(qualificationId,
+                                                    "Qualification Name",
+                                                    AwardingOrganisations.Ncfe,
+                                                    level)
+                                  {
+                                      FromWhichYear = "2014", ToWhichYear = "2019",
+                                      QualificationNumber = "ABC/547/900",
+                                      AdditionalRequirements = "additional requirements",
+                                      RatioRequirements = ratioRequirements
+                                  };
 
         mockContentService.Setup(x => x.GetQualificationById(qualificationId)).ReturnsAsync(qualificationResult);
         mockContentService.Setup(x => x.GetDetailsPage()).ReturnsAsync(new DetailsPage());

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -39,7 +39,7 @@ public class QuestionsControllerTests
                                                  mockQuestionModelValidator.Object);
 
         var result = await controller.WhereWasTheQualificationAwarded();
-        
+
         mockUserJourneyCookieService.Verify(x => x.ResetUserJourneyCookie(), Times.Once);
 
         mockContentService.VerifyAll();
@@ -79,7 +79,7 @@ public class QuestionsControllerTests
                                                  mockQuestionModelValidator.Object);
 
         var result = await controller.WhereWasTheQualificationAwarded();
-        
+
         mockUserJourneyCookieService.Verify(x => x.ResetUserJourneyCookie(), Times.Once);
 
         result.Should().NotBeNull();
@@ -141,7 +141,10 @@ public class QuestionsControllerTests
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
-                                                             { Option = QualificationAwardLocation.OutsideOfTheUnitedKingdom });
+                                                             {
+                                                                 Option = QualificationAwardLocation
+                                                                     .OutsideOfTheUnitedKingdom
+                                                             });
 
         result.Should().NotBeNull();
 
@@ -153,7 +156,7 @@ public class QuestionsControllerTests
 
         mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(It.IsAny<string>()), Times.Never);
     }
-    
+
     [TestMethod]
     public async Task Post_WhereWasTheQualificationAwarded_PassInScotland_RedirectsToAdvicePage()
     {
@@ -182,7 +185,7 @@ public class QuestionsControllerTests
 
         mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(It.IsAny<string>()), Times.Never);
     }
-    
+
     [TestMethod]
     public async Task Post_WhereWasTheQualificationAwarded_PassInWales_RedirectsToAdvicePage()
     {
@@ -211,7 +214,7 @@ public class QuestionsControllerTests
 
         mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(It.IsAny<string>()), Times.Never);
     }
-    
+
     [TestMethod]
     public async Task Post_WhereWasTheQualificationAwarded_PassInNorthernIreland_RedirectsToAdvicePage()
     {
@@ -256,7 +259,8 @@ public class QuestionsControllerTests
                                                  mockQuestionModelValidator.Object);
 
         var result =
-            await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel { Option = QualificationAwardLocation.England });
+            await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
+                                                             { Option = QualificationAwardLocation.England });
 
         result.Should().NotBeNull();
 
@@ -265,7 +269,8 @@ public class QuestionsControllerTests
 
         resultType!.ActionName.Should().Be("WhenWasTheQualificationStarted");
 
-        mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(QualificationAwardLocation.England), Times.Once);
+        mockUserJourneyCookieService.Verify(x => x.SetWhereWasQualificationAwarded(QualificationAwardLocation.England),
+                                            Times.Once);
     }
 
     [TestMethod]
@@ -679,7 +684,7 @@ public class QuestionsControllerTests
         resultType!.ActionName.Should().Be("QualificationsStartedBetweenSept2014AndAug2019");
         resultType.ControllerName.Should().Be("Advice");
     }
-    
+
     [TestMethod]
     public async Task Post_WhatLevelIsTheQualification_Level6Pre2014_ReturnsRedirectResponse()
     {
@@ -709,7 +714,7 @@ public class QuestionsControllerTests
         resultType!.ActionName.Should().Be("Level6QualificationPre2014");
         resultType.ControllerName.Should().Be("Advice");
     }
-    
+
     [TestMethod]
     public async Task Post_WhatLevelIsTheQualification_Level6Post2014_ReturnsRedirectResponse()
     {
@@ -882,20 +887,15 @@ public class QuestionsControllerTests
         var listOfQualifications = new List<Qualification>
                                    {
                                        new("1", "TEST",
-                                           "D awarding organisation", 123, null,
-                                           null, null, null, null, null),
+                                           "D awarding organisation", 123),
                                        new("2", "TEST",
-                                           "E awarding organisation", 123, null,
-                                           null, null, null, null, null),
+                                           "E awarding organisation", 123),
                                        new("3", "TEST",
-                                           "A awarding organisation", 123, null,
-                                           null, null, null, null, null),
+                                           "A awarding organisation", 123),
                                        new("4", "TEST",
-                                           "C awarding organisation", 123, null,
-                                           null, null, null, null, null),
+                                           "C awarding organisation", 123),
                                        new("5", "TEST",
-                                           "B awarding organisation", 123, null,
-                                           null, null, null, null, null)
+                                           "B awarding organisation", 123)
                                    };
 
         mockUserJourneyCookieService.Setup(x => x.GetUserJourneyModelFromCookie()).Returns(new UserJourneyModel());
@@ -953,17 +953,13 @@ public class QuestionsControllerTests
         var listOfQualifications = new List<Qualification>
                                    {
                                        new("1", "TEST",
-                                           "D awarding organisation", 123, null,
-                                           null, null, null, null, null),
+                                           "D awarding organisation", 123),
                                        new("2", "TEST",
-                                           "E awarding organisation", 123, null,
-                                           null, null, null, null, null),
+                                           "E awarding organisation", 123),
                                        new("3", "TEST",
-                                           AwardingOrganisations.Various, 123, null,
-                                           null, null, null, null, null),
+                                           AwardingOrganisations.Various, 123),
                                        new("4", "TEST",
-                                           AwardingOrganisations.AllHigherEducation, 123, null,
-                                           null, null, null, null, null)
+                                           AwardingOrganisations.AllHigherEducation, 123)
                                    };
 
         mockUserJourneyCookieService.Setup(x => x.GetUserJourneyModelFromCookie()).Returns(new UserJourneyModel());

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentFilterServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentFilterServiceTests.cs
@@ -21,28 +21,25 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-741",
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-741",
                                                         "test",
                                                         AwardingOrganisations.Pearson,
-                                                        3,
-                                                        null,
-                                                        "Aug-19",
-                                                        "def/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        3)
+                                      {
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "def/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
         var mockContentfulClient = new Mock<IContentfulClient>();
@@ -77,17 +74,16 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -122,17 +118,16 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -168,39 +163,34 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-741",
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-741",
                                                         "test",
                                                         AwardingOrganisations.Pearson,
-                                                        4,
-                                                        null,
-                                                        "Aug-19",
-                                                        "def/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-752",
+                                                        4)
+                                      {
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "def/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-752",
                                                         "test",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Sep-21",
-                                                        null,
-                                                        "ghi/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Sep-21",
+                                          QualificationNumber = "ghi/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
         var mockContentfulClient = new Mock<IContentfulClient>();
@@ -235,39 +225,34 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-741",
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-741",
                                                         "test",
                                                         AwardingOrganisations.Pearson,
-                                                        4,
-                                                        null,
-                                                        "Aug-19",
-                                                        "def/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-752",
+                                                        4)
+                                      {
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "def/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-752",
                                                         "test",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Sep-21",
-                                                        null,
-                                                        "ghi/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Sep-21",
+                                          QualificationNumber = "ghi/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
         var mockContentfulClient = new Mock<IContentfulClient>();
@@ -302,50 +287,43 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-741",
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-741",
                                                         "test",
                                                         AwardingOrganisations.Pearson,
-                                                        4,
-                                                        null,
-                                                        "Sep-19",
-                                                        "def/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-746",
+                                                        4)
+                                      {
+                                          ToWhichYear = "Sep-19",
+                                          QualificationNumber = "def/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-746",
                                                         "test",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Sep-15",
-                                                        null,
-                                                        "ghi/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-752",
+                                                        4)
+                                      {
+                                          FromWhichYear = "Sep-15",
+                                          QualificationNumber = "ghi/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-752",
                                                         "test",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Sep-21",
-                                                        null,
-                                                        "ghi/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Sep-21",
+                                          QualificationNumber = "ghi/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
         var mockContentfulClient = new Mock<IContentfulClient>();
@@ -380,50 +358,43 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-741",
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-741",
                                                         "test",
                                                         AwardingOrganisations.Pearson,
-                                                        4,
-                                                        null,
-                                                        "seP-19",
-                                                        "def/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-746",
+                                                        4)
+                                      {
+                                          ToWhichYear = "seP-19",
+                                          QualificationNumber = "def/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-746",
                                                         "test",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "sEp-15",
-                                                        null,
-                                                        "ghi/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-752",
+                                                        4)
+                                      {
+                                          FromWhichYear = "sEp-15",
+                                          QualificationNumber = "ghi/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-752",
                                                         "test",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "SEP-21",
-                                                        null,
-                                                        "ghi/456/951",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "SEP-21",
+                                          QualificationNumber = "ghi/456/951",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
         var mockContentfulClient = new Mock<IContentfulClient>();
@@ -479,17 +450,17 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Sep15", // We expect Mmm-yy, e.g. "Sep-15"
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear =
+                                              "Sep15", // We expect Mmm-yy, e.g. "Sep-15"
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -521,17 +492,17 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Sept-15", // "Sept" in the data: we expect "Sep"
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear =
+                                              "Sept-15", // "Sept" in the data: we expect "Sep"
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -563,17 +534,16 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Sep-15",
-                                                        "Aug-1a", // invalid year typo
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Sep-15",
+                                          ToWhichYear = "Aug-1a", // invalid year typo
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -605,17 +575,16 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Pearson,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -651,17 +620,16 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Pearson,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -691,23 +659,22 @@ public class ContentfulContentFilterServiceTests
     }
 
     [TestMethod]
-    public async Task GetFilteredQualifications_PassInNCFEAndNoStartDate_QueryDoesntContainCache()
+    public async Task GetFilteredQualifications_PassInNcfeAndNoStartDate_QueryDoesntContainCache()
     {
         var results = new ContentfulCollection<Qualification>
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -737,23 +704,22 @@ public class ContentfulContentFilterServiceTests
     }
 
     [TestMethod]
-    public async Task GetFilteredQualifications_PassInCACHEAndNoStartDate_QueryDoesntContainNCFE()
+    public async Task GetFilteredQualifications_PassInCacheAndNoStartDate_QueryDoesntContainNcfe()
     {
         var results = new ContentfulCollection<Qualification>
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -783,23 +749,22 @@ public class ContentfulContentFilterServiceTests
     }
 
     [TestMethod]
-    public async Task GetFilteredQualifications_PassInNCFEAndStartDateLessThanSept14_QueryDoesntContainCache()
+    public async Task GetFilteredQualifications_PassInNcfeAndStartDateLessThanSept14_QueryDoesntContainCache()
     {
         var results = new ContentfulCollection<Qualification>
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -829,23 +794,22 @@ public class ContentfulContentFilterServiceTests
     }
 
     [TestMethod]
-    public async Task GetFilteredQualifications_PassInCACHEAndStartDateLessThanSept14_QueryDoesntContainNCFE()
+    public async Task GetFilteredQualifications_PassInCacheAndStartDateLessThanSept14_QueryDoesntContainNcfe()
     {
         var results = new ContentfulCollection<Qualification>
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -875,23 +839,22 @@ public class ContentfulContentFilterServiceTests
     }
 
     [TestMethod]
-    public async Task GetFilteredQualifications_PassInNCFEAndStartDateGreaterThanSept14_QueryContainsCache()
+    public async Task GetFilteredQualifications_PassInNcfeAndStartDateGreaterThanSept14_QueryContainsCache()
     {
         var results = new ContentfulCollection<Qualification>
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Ncfe,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -921,23 +884,22 @@ public class ContentfulContentFilterServiceTests
     }
 
     [TestMethod]
-    public async Task GetFilteredQualifications_PassInCACHEAndStartDateGreaterThanSept14_QueryContainsNCFE()
+    public async Task GetFilteredQualifications_PassInCacheAndStartDateGreaterThanSept14_QueryContainsNcfe()
     {
         var results = new ContentfulCollection<Qualification>
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         "test",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -978,28 +940,26 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         technicalDiplomaInChildCare,
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-123",
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-123",
                                                         "Diploma in Early Years Child Care",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 
@@ -1041,28 +1001,26 @@ public class ContentfulContentFilterServiceTests
                       {
                           Items = new[]
                                   {
-                                      new Qualification(
-                                                        "EYQ-123",
+                                      new Qualification("EYQ-123",
                                                         technicalDiplomaInChildCare,
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null),
-                                      new Qualification(
-                                                        "EYQ-123",
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      },
+                                      new Qualification("EYQ-123",
                                                         "Diploma in Early Years Child Care",
                                                         AwardingOrganisations.Cache,
-                                                        4,
-                                                        "Apr-15",
-                                                        "Aug-19",
-                                                        "abc/123/987",
-                                                        "requirements",
-                                                        null,
-                                                        null)
+                                                        4)
+                                      {
+                                          FromWhichYear = "Apr-15",
+                                          ToWhichYear = "Aug-19",
+                                          QualificationNumber = "abc/123/987",
+                                          AdditionalRequirements = "requirements"
+                                      }
                                   }
                       };
 

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/ContentfulContentServiceTests.cs
@@ -677,9 +677,16 @@ public class ContentfulContentServiceTests
     [TestMethod]
     public async Task GetQualificationById_QualificationExists_Returns()
     {
-        var qualification = new Qualification("SomeId", "Test qualification name", "Test awarding org", 123,
-                                              "Test from which year", "Test to which year", "Test qualification number",
-                                              "Test additional requirements", null, null);
+        var qualification = new Qualification("SomeId",
+                                              "Test qualification name",
+                                              "Test awarding org",
+                                              123)
+                            {
+                                FromWhichYear = "Test from which year",
+                                ToWhichYear = "Test to which year",
+                                QualificationNumber = "Test qualification number",
+                                AdditionalRequirements = "Test additional requirements"
+                            };
 
         _clientMock.Setup(client =>
                               client.GetEntriesByType(
@@ -852,10 +859,14 @@ public class ContentfulContentServiceTests
     [TestMethod]
     public async Task GetQualifications_ReturnsQualifications()
     {
-        var qualification = new Qualification("Id", "Name",
-                                              "AO", 6,
-                                              "2014", "2020",
-                                              "number", "Rq", null, null);
+        var qualification = new Qualification("Id",
+                                              "Name",
+                                              "AO",
+                                              6)
+                            {
+                                FromWhichYear = "2014", ToWhichYear = "2020",
+                                QualificationNumber = "number", AdditionalRequirements = "Rq"
+                            };
 
         _clientMock.Setup(c =>
                               c.GetEntriesByType(It.IsAny<string>(),
@@ -901,7 +912,7 @@ public class ContentfulContentServiceTests
 
         _logger.VerifyError($"Exception trying to retrieve {nameof(StartPage)} from Contentful.");
     }
-    
+
     [TestMethod]
     public async Task GetCheckAdditionalRequirementsPage_ReturnsPage()
     {


### PR DESCRIPTION
# Description

SonarCloud suggestion: these `Qualification` class constructors don't need 10 parameters.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules