### PR TITLE
EYQB-500: Updated logic to add in new error messages for the When was the qualification started page

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Content/Entities/DateQuestionPage.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/DateQuestionPage.cs
@@ -7,9 +7,7 @@ public class DateQuestionPage
     public string Question { get; init; } = string.Empty;
 
     public string CtaButtonText { get; init; } = string.Empty;
-
-    public string ErrorMessage { get; init; } = string.Empty;
-
+    
     public string QuestionHint { get; init; } = string.Empty;
 
     public string MonthLabel { get; init; } = string.Empty;
@@ -18,11 +16,21 @@ public class DateQuestionPage
 
     public NavigationLink? BackButton { get; init; }
     
+    public string AdditionalInformationHeader { get; init; } = string.Empty;
+
+    public Document? AdditionalInformationBody { get; init; }
+    
     public string ErrorBannerHeading { get; init; } = string.Empty;
 
     public string ErrorBannerLinkText { get; init; } = string.Empty;
     
-    public string AdditionalInformationHeader { get; init; } = string.Empty;
-
-    public Document? AdditionalInformationBody { get; init; }
+    public string ErrorMessage { get; init; } = string.Empty;
+    
+    public string FutureDateErrorBannerLinkText { get; init; } = string.Empty;
+    
+    public string FutureDateErrorMessage { get; init; } = string.Empty;
+    
+    public string IncorrectFormatErrorBannerLinkText { get; init; } = string.Empty;
+    
+    public string IncorrectFormatErrorMessage { get; init; } = string.Empty;
 }

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
@@ -554,7 +554,6 @@ public class MockContentfulService : IContentService
                {
                    Question = "Test Date Question",
                    CtaButtonText = "Continue",
-                   ErrorMessage = "Test Error Message",
                    MonthLabel = "Test Month Label",
                    YearLabel = "Test Year Label",
                    QuestionHint = "Test Question Hint",
@@ -564,11 +563,16 @@ public class MockContentfulService : IContentService
                                     Href = WhereWasTheQualificationAwardedPath,
                                     OpenInNewTab = false
                                 },
-                   ErrorBannerHeading = "There is a problem",
-                   ErrorBannerLinkText = "Test error banner link text",
                    AdditionalInformationBody =
                        ContentfulContentHelper.Paragraph("This is the additional information body"),
-                   AdditionalInformationHeader = "This is the additional information header"
+                   AdditionalInformationHeader = "This is the additional information header",
+                   ErrorBannerHeading = "There is a problem",
+                   ErrorBannerLinkText = "Test error banner link text",
+                   ErrorMessage = "Test Error Message",
+                   FutureDateErrorBannerLinkText = "Future date error message banner link",
+                   FutureDateErrorMessage = "Future date error message",
+                   IncorrectFormatErrorBannerLinkText = "Enter a month between 1 and 12 and a year between 1900 and $[actual-year]$",
+                   IncorrectFormatErrorMessage = "Incorrect format error message banner link"
                };
     }
 

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
@@ -301,7 +301,7 @@ public class QuestionsController(
         model.BackButton = MapToNavigationLinkModel(question.BackButton);
         model.ErrorBannerHeading = question.ErrorBannerHeading;
         model.ErrorBannerLinkText = placeholderUpdater.Replace(validationResult?.BannerErrorMessage ?? question.ErrorBannerLinkText);
-        model.ErrorMessage = placeholderUpdater.Replace(validationResult is not null ? validationResult.ErrorMessage : question.ErrorMessage);
+        model.ErrorMessage = placeholderUpdater.Replace(validationResult?.ErrorMessage ?? question.ErrorMessage);
         model.AdditionalInformationHeader = question.AdditionalInformationHeader;
         model.AdditionalInformationBody = await renderer.ToHtml(question.AdditionalInformationBody);
         return model;

--- a/src/Dfe.EarlyYearsQualification.Web/Helpers/IPlaceholderUpdater.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Helpers/IPlaceholderUpdater.cs
@@ -2,5 +2,5 @@ namespace Dfe.EarlyYearsQualification.Web.Helpers;
 
 public interface IPlaceholderUpdater
 {
-    string Replace(string valueToCheck);
+    string Replace(string text);
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Helpers/IPlaceholderUpdater.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Helpers/IPlaceholderUpdater.cs
@@ -1,0 +1,6 @@
+namespace Dfe.EarlyYearsQualification.Web.Helpers;
+
+public interface IPlaceholderUpdater
+{
+    string Replace(string valueToCheck);
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Helpers/PlaceholderUpdater.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Helpers/PlaceholderUpdater.cs
@@ -1,20 +1,23 @@
+using Dfe.EarlyYearsQualification.Web.Services.DatesAndTimes;
+
 namespace Dfe.EarlyYearsQualification.Web.Helpers;
 
-public class PlaceholderUpdater : IPlaceholderUpdater
+public class PlaceholderUpdater(IDateTimeAdapter dateTimeAdapter) : IPlaceholderUpdater
 {
+    
     private readonly Dictionary<string, string> _placeholders = new()
                                                                 {
-                                                                    { "$[actual-year]$", DateTimeOffset.Now.Year.ToString() }
+                                                                    { "$[actual-year]$", dateTimeAdapter.Now().Year.ToString() }
                                                                 };
 
-    public string Replace(string valueToCheck)
+    public string Replace(string text)
     {
-        if (string.IsNullOrEmpty(valueToCheck)) return valueToCheck;
+        if (string.IsNullOrEmpty(text)) return text;
         
-        var result = valueToCheck;
+        var result = text;
         foreach (var placeholder in _placeholders)
         {
-            if (valueToCheck.Contains(placeholder.Key))
+            if (text.Contains(placeholder.Key))
             {
                 result = result.Replace(placeholder.Key, placeholder.Value);
             }

--- a/src/Dfe.EarlyYearsQualification.Web/Helpers/PlaceholderUpdater.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Helpers/PlaceholderUpdater.cs
@@ -1,0 +1,25 @@
+namespace Dfe.EarlyYearsQualification.Web.Helpers;
+
+public class PlaceholderUpdater : IPlaceholderUpdater
+{
+    private readonly Dictionary<string, string> _placeholders = new()
+                                                                {
+                                                                    { "$[actual-year]$", DateTimeOffset.Now.Year.ToString() }
+                                                                };
+
+    public string Replace(string valueToCheck)
+    {
+        if (string.IsNullOrEmpty(valueToCheck)) return valueToCheck;
+        
+        var result = valueToCheck;
+        foreach (var placeholder in _placeholders)
+        {
+            if (valueToCheck.Contains(placeholder.Key))
+            {
+                result = result.Replace(placeholder.Key, placeholder.Value);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Helpers/PlaceholderUpdater.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Helpers/PlaceholderUpdater.cs
@@ -4,23 +4,15 @@ namespace Dfe.EarlyYearsQualification.Web.Helpers;
 
 public class PlaceholderUpdater(IDateTimeAdapter dateTimeAdapter) : IPlaceholderUpdater
 {
-    
-    private readonly Dictionary<string, string> _placeholders = new()
-                                                                {
-                                                                    { "$[actual-year]$", dateTimeAdapter.Now().Year.ToString() }
-                                                                };
-
+    private const string ActualYearPlaceholder = "$[actual-year]$";
     public string Replace(string text)
     {
         if (string.IsNullOrEmpty(text)) return text;
         
         var result = text;
-        foreach (var placeholder in _placeholders)
+        if (text.Contains(ActualYearPlaceholder))
         {
-            if (text.Contains(placeholder.Key))
-            {
-                result = result.Replace(placeholder.Key, placeholder.Value);
-            }
+            result = result.Replace(ActualYearPlaceholder, dateTimeAdapter.Now().Year.ToString());
         }
 
         return result;

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/DateQuestionModelValidator.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/DateQuestionModelValidator.cs
@@ -1,22 +1,43 @@
+using Dfe.EarlyYearsQualification.Content.Entities;
 using Dfe.EarlyYearsQualification.Web.Services.DatesAndTimes;
 
 namespace Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
 
 public class DateQuestionModelValidator(IDateTimeAdapter dateTimeAdapter) : IDateQuestionModelValidator
 {
-    public bool IsValid(DateQuestionModel model)
+    public ValidationResult IsValid(DateQuestionModel model, DateQuestionPage questionPage)
     {
+        if (model is { SelectedYear: 0, SelectedMonth: 0 })
+        {
+            return new ValidationResult
+                   {
+                       IsValid = false, 
+                       ErrorMessage = questionPage.ErrorMessage, 
+                       BannerErrorMessage = questionPage.ErrorBannerLinkText
+                   };
+        }
+        
         if (model.SelectedYear < 1900
             || model.SelectedMonth < 1
             || model.SelectedMonth > 12)
         {
-            return false;
+            return new ValidationResult
+                   {
+                       IsValid = false, 
+                       ErrorMessage = questionPage.IncorrectFormatErrorMessage, 
+                       BannerErrorMessage = questionPage.IncorrectFormatErrorBannerLinkText
+                   };
         }
 
         var selectedDate = new DateOnly(model.SelectedYear, model.SelectedMonth, 1);
 
         var now = dateTimeAdapter.Now();
 
-        return selectedDate <= DateOnly.FromDateTime(now);
+        return new ValidationResult
+               {
+                   IsValid = selectedDate <= DateOnly.FromDateTime(now),
+                   ErrorMessage = questionPage.FutureDateErrorMessage,
+                   BannerErrorMessage = questionPage.FutureDateErrorBannerLinkText
+               };
     }
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/IDateQuestionModelValidator.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/IDateQuestionModelValidator.cs
@@ -1,6 +1,8 @@
+using Dfe.EarlyYearsQualification.Content.Entities;
+
 namespace Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
 
 public interface IDateQuestionModelValidator
 {
-    bool IsValid(DateQuestionModel model);
+    ValidationResult IsValid(DateQuestionModel model, DateQuestionPage questionPage);
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/ValidationResult.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/ValidationResult.cs
@@ -1,0 +1,10 @@
+namespace Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
+
+public class ValidationResult
+{
+    public bool IsValid { get; init; }
+
+    public string BannerErrorMessage { get; init; } = string.Empty;
+
+    public string ErrorMessage { get; init; } = string.Empty;
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Program.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Program.cs
@@ -72,7 +72,7 @@ builder.Services.AddSingleton<IFuzzyAdapter, FuzzyAdapter>();
 builder.Services.AddSingleton<IDateTimeAdapter, DateTimeAdapter>();
 builder.Services.AddSingleton<IDateQuestionModelValidator, DateQuestionModelValidator>();
 builder.Services.AddTransient<GtmConfiguration>();
-builder.Services.AddTransient<IPlaceholderUpdater, PlaceholderUpdater>();
+builder.Services.AddSingleton<IPlaceholderUpdater, PlaceholderUpdater>();
 
 var accessIsChallenged = !builder.Configuration.GetValue<bool>("ServiceAccess:IsPublic");
 // ...by default, challenge the user for the secret value unless that's explicitly turned off

--- a/src/Dfe.EarlyYearsQualification.Web/Program.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Program.cs
@@ -72,6 +72,7 @@ builder.Services.AddSingleton<IFuzzyAdapter, FuzzyAdapter>();
 builder.Services.AddSingleton<IDateTimeAdapter, DateTimeAdapter>();
 builder.Services.AddSingleton<IDateQuestionModelValidator, DateQuestionModelValidator>();
 builder.Services.AddTransient<GtmConfiguration>();
+builder.Services.AddTransient<IPlaceholderUpdater, PlaceholderUpdater>();
 
 var accessIsChallenged = !builder.Configuration.GetValue<bool>("ServiceAccess:IsPublic");
 // ...by default, challenge the user for the secret value unless that's explicitly turned off

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/pages/question-spec.cy.js
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/pages/question-spec.cy.js
@@ -90,7 +90,56 @@ describe("A spec that tests question pages", () => {
       cy.get('#date-error').should("exist");
       cy.get('#date-error').should("contain.text", "Test Error Message");
       cy.get(".govuk-form-group").should("have.class", "govuk-form-group--error");
-  })
+    })
+
+    it("shows an error message when a user puts a date in the future on when-was-the-qualification-started page", () => {
+        cy.visit("/questions/when-was-the-qualification-started");
+
+        cy.get(".govuk-error-summary").should("not.exist");
+        cy.get("#date-error").should("not.exist");
+        cy.get(".govuk-form-group").should("not.have.class", "govuk-form-group--error");
+
+        cy.get('#date-started-month').type(10);
+        cy.get('#date-started-year').type(3000);
+        
+        cy.get('button[id="question-submit"]').click();
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq("/questions/when-was-the-qualification-started");
+        })
+
+        cy.get(".govuk-error-summary").should("be.visible");
+        cy.get(".govuk-error-summary__title").should("contain.text", "There is a problem");
+        cy.get("#error-banner-link").should("contain.text", "Future date error message banner link");
+
+        cy.get('#date-error').should("exist");
+        cy.get('#date-error').should("contain.text", "Future date error message");
+        cy.get(".govuk-form-group").should("have.class", "govuk-form-group--error");
+    })
+
+    it("shows an error message when a user puts an invalid format in on when-was-the-qualification-started page", () => {
+        cy.visit("/questions/when-was-the-qualification-started");
+
+        cy.get(".govuk-error-summary").should("not.exist");
+        cy.get("#date-error").should("not.exist");
+        cy.get(".govuk-form-group").should("not.have.class", "govuk-form-group--error");
+
+        cy.get('#date-started-month').type(10);
+        cy.get('#date-started-year').type(24);
+
+        cy.get('button[id="question-submit"]').click();
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq("/questions/when-was-the-qualification-started");
+        })
+
+        cy.get(".govuk-error-summary").should("be.visible");
+        cy.get(".govuk-error-summary__title").should("contain.text", "There is a problem");
+        let year = new Date().getFullYear();
+        cy.get("#error-banner-link").should("contain.text", `Enter a month between 1 and 12 and a year between 1900 and ${year}`);
+
+        cy.get('#date-error').should("exist");
+        cy.get('#date-error').should("contain.text", "Incorrect format error message banner link");
+        cy.get(".govuk-form-group").should("have.class", "govuk-form-group--error");
+    })
 
     /// What level is the qualification page
     it("Checks the content on what-level-is-the-qualification page", () => {

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -7,6 +7,7 @@ using Dfe.EarlyYearsQualification.Mock.Helpers;
 using Dfe.EarlyYearsQualification.UnitTests.Extensions;
 using Dfe.EarlyYearsQualification.Web.Constants;
 using Dfe.EarlyYearsQualification.Web.Controllers;
+using Dfe.EarlyYearsQualification.Web.Helpers;
 using Dfe.EarlyYearsQualification.Web.Models;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
@@ -30,13 +31,14 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         mockContentService.Setup(x => x.GetRadioQuestionPage(QuestionPages.WhereWasTheQualificationAwarded))
                           .ReturnsAsync((RadioQuestionPage?)default).Verifiable();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhereWasTheQualificationAwarded();
 
@@ -64,6 +66,7 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var questionPage = new RadioQuestionPage
                            {
@@ -76,7 +79,7 @@ public class QuestionsControllerTests
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhereWasTheQualificationAwarded();
 
@@ -109,10 +112,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         controller.ModelState.AddModelError("option", "test error");
         var result = await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel());
@@ -136,10 +140,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
@@ -168,10 +173,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
@@ -197,10 +203,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
@@ -226,10 +233,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
@@ -255,10 +263,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result =
             await controller.WhereWasTheQualificationAwarded(new RadioQuestionModel
@@ -284,6 +293,7 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var questionPage = new DateQuestionPage
                            {
@@ -296,10 +306,12 @@ public class QuestionsControllerTests
                            };
         mockContentService.Setup(x => x.GetDateQuestionPage(QuestionPages.WhenWasTheQualificationStarted))
                           .ReturnsAsync(questionPage);
+        
+        mockPlaceholderUpdater.Setup(x => x.Replace(It.IsAny<string>())).Returns<string>(x => x);
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhenWasTheQualificationStarted();
 
@@ -310,9 +322,7 @@ public class QuestionsControllerTests
 
         var model = resultType!.Model as DateQuestionModel;
         model.Should().NotBeNull();
-
-        // The following will need to be replaced once the page has been created in Contentful.
-        // The model is currently hard coded in the action and doesn't call the content service.
+        
         model!.Question.Should().Be(questionPage.Question);
         model.CtaButtonText.Should().Be(questionPage.CtaButtonText);
         model.HasErrors.Should().BeFalse();
@@ -331,13 +341,14 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         mockContentService.Setup(x => x.GetDateQuestionPage(QuestionPages.WhenWasTheQualificationStarted))
                           .ReturnsAsync((DateQuestionPage?)default).Verifiable();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhenWasTheQualificationStarted();
 
@@ -360,12 +371,29 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
+        var questionPage = new DateQuestionPage
+                           {
+                               Question = "Test question",
+                               CtaButtonText = "Continue",
+                               ErrorMessage = "Test error message",
+                               MonthLabel = "Test month label",
+                               YearLabel = "Test year label",
+                               QuestionHint = "Test question hint"
+                           };
+        mockContentService.Setup(x => x.GetDateQuestionPage(QuestionPages.WhenWasTheQualificationStarted))
+                          .ReturnsAsync(questionPage);
+        
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
-        controller.ModelState.AddModelError("option", "test error");
+        mockQuestionModelValidator.Setup(x => x.IsValid(It.IsAny<DateQuestionModel>(), It.IsAny<DateQuestionPage>()))
+                                  .Returns(new ValidationResult { IsValid = false, ErrorMessage = "Test error message" });
+
+        mockPlaceholderUpdater.Setup(x => x.Replace(It.IsAny<string>())).Returns<string>(x => x);
+        
         var result = await controller.WhenWasTheQualificationStarted(new DateQuestionModel());
 
         result.Should().NotBeNull();
@@ -374,100 +402,8 @@ public class QuestionsControllerTests
         resultType.Should().NotBeNull();
 
         resultType!.ViewName.Should().Be("Date");
-
-        mockUserJourneyCookieService.Verify(x => x.SetWhenWasQualificationAwarded(It.IsAny<string>()), Times.Never);
-    }
-
-    [TestMethod]
-    [DataRow(-1, 2020)]
-    [DataRow(13, 2020)]
-    [DataRow(0, 2020)]
-    [DataRow(1, 1899)]
-    public async Task Post_WhenWasTheQualificationStarted_PassedInvalidValues_ReturnsBackToPageWithErrorTag(
-        int month, int year)
-    {
-        var mockLogger = new Mock<ILogger<QuestionsController>>();
-        var mockContentService = new Mock<IContentService>();
-        var mockRenderer = new Mock<IHtmlRenderer>();
-        var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
-        var mockContentFilterService = new Mock<IContentFilterService>();
-        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
-
-        var questionPage = new DateQuestionPage
-                           {
-                               Question = "Test question",
-                               CtaButtonText = "Continue",
-                               ErrorMessage = "Test error message",
-                               MonthLabel = "Test month label",
-                               YearLabel = "Test year label",
-                               QuestionHint = "Test question hint"
-                           };
-        mockContentService.Setup(x => x.GetDateQuestionPage(QuestionPages.WhenWasTheQualificationStarted))
-                          .ReturnsAsync(questionPage);
-
-        var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
-
-        var result = await controller.WhenWasTheQualificationStarted(new DateQuestionModel
-                                                                     {
-                                                                         SelectedMonth = month,
-                                                                         SelectedYear = year
-                                                                     });
-
-        var resultType = result as ViewResult;
-        resultType.Should().NotBeNull();
-
-        var model = resultType!.Model as DateQuestionModel;
-        model.Should().NotBeNull();
-
-        model!.Question.Should().Be(questionPage.Question);
-        model.CtaButtonText.Should().Be(questionPage.CtaButtonText);
-        model.HasErrors.Should().BeTrue();
-        model.ErrorMessage.Should().Be(questionPage.ErrorMessage);
-        model.MonthLabel.Should().Be(questionPage.MonthLabel);
-        model.YearLabel.Should().Be(questionPage.YearLabel);
-        model.QuestionHint.Should().Be(questionPage.QuestionHint);
-
-        mockUserJourneyCookieService.Verify(x => x.SetWhenWasQualificationAwarded(It.IsAny<string>()), Times.Never);
-    }
-
-    [TestMethod]
-    public async Task Post_WhenWasTheQualificationStarted_YearProvidedIsNextYear_ReturnsRedirectResponse()
-    {
-        var mockLogger = new Mock<ILogger<QuestionsController>>();
-        var mockContentService = new Mock<IContentService>();
-        var mockRenderer = new Mock<IHtmlRenderer>();
-        var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
-        var mockContentFilterService = new Mock<IContentFilterService>();
-        var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
-
-        var questionPage = new DateQuestionPage
-                           {
-                               Question = "Test question",
-                               CtaButtonText = "Continue",
-                               ErrorMessage = "Test error message",
-                               MonthLabel = "Test month label",
-                               YearLabel = "Test year label",
-                               QuestionHint = "Test question hint"
-                           };
-        mockContentService.Setup(x => x.GetDateQuestionPage(QuestionPages.WhenWasTheQualificationStarted))
-                          .ReturnsAsync(questionPage);
-
-        var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
-                                                 mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
-
-        var result = await controller.WhenWasTheQualificationStarted(new DateQuestionModel
-                                                                     {
-                                                                         SelectedMonth = 01,
-                                                                         SelectedYear = DateTime.UtcNow.Year + 1
-                                                                     });
-
-        var resultType = result as ViewResult;
-        resultType.Should().NotBeNull();
-
-        var model = resultType!.Model as DateQuestionModel;
+        
+        var model = resultType.Model as DateQuestionModel;
         model.Should().NotBeNull();
 
         model!.Question.Should().Be(questionPage.Question);
@@ -490,14 +426,15 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         mockQuestionModelValidator
-            .Setup(x => x.IsValid(It.IsAny<DateQuestionModel>()))
-            .Returns(true);
+            .Setup(x => x.IsValid(It.IsAny<DateQuestionModel>(), It.IsAny<DateQuestionPage>()))
+            .Returns(new ValidationResult { IsValid = true });
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         const int selectedMonth = 12;
         const int selectedYear = 2024;
@@ -529,13 +466,14 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         mockContentService.Setup(x => x.GetRadioQuestionPage(QuestionPages.WhatLevelIsTheQualification))
                           .ReturnsAsync((RadioQuestionPage?)default).Verifiable();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatLevelIsTheQualification();
 
@@ -561,6 +499,7 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var questionPage = new RadioQuestionPage
                            {
@@ -577,7 +516,7 @@ public class QuestionsControllerTests
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatLevelIsTheQualification();
 
@@ -612,10 +551,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         controller.ModelState.AddModelError("option", "test error");
         var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel());
@@ -639,10 +579,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel
                                                                   {
@@ -668,12 +609,13 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         mockUserJourneyCookieService.Setup(x => x.GetWhenWasQualificationAwarded())
                                     .Returns((6, 2015));
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel
                                                                   {
@@ -698,12 +640,13 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         mockUserJourneyCookieService.Setup(x => x.GetWhenWasQualificationAwarded())
                                     .Returns((7, 2014));
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel
                                                                   {
@@ -728,12 +671,13 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         mockUserJourneyCookieService.Setup(x => x.GetWhenWasQualificationAwarded())
                                     .Returns((7, 2015));
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel
                                                                   {
@@ -758,12 +702,13 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         mockUserJourneyCookieService.Setup(x => x.GetWhenWasQualificationAwarded())
                                     .Returns((6, 2015));
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatLevelIsTheQualification(new RadioQuestionModel
                                                                   {
@@ -788,13 +733,14 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         mockContentService.Setup(x => x.GetDropdownQuestionPage(QuestionPages.WhatIsTheAwardingOrganisation))
                           .ReturnsAsync((DropdownQuestionPage?)default).Verifiable();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation();
 
@@ -820,6 +766,7 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -846,7 +793,7 @@ public class QuestionsControllerTests
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation();
 
@@ -879,6 +826,7 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -910,7 +858,7 @@ public class QuestionsControllerTests
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation();
 
@@ -945,6 +893,7 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -974,7 +923,7 @@ public class QuestionsControllerTests
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation();
 
@@ -1002,10 +951,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -1053,10 +1003,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var result = await controller.WhatIsTheAwardingOrganisation(new DropdownQuestionModel
                                                                     {
@@ -1084,10 +1035,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var questionPage = new DropdownQuestionPage
                            {
@@ -1135,10 +1087,11 @@ public class QuestionsControllerTests
         var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
         var mockContentFilterService = new Mock<IContentFilterService>();
         var mockQuestionModelValidator = new Mock<IDateQuestionModelValidator>();
+        var mockPlaceholderUpdater = new Mock<IPlaceholderUpdater>();
 
         var controller = new QuestionsController(mockLogger.Object, mockContentService.Object, mockRenderer.Object,
                                                  mockUserJourneyCookieService.Object, mockContentFilterService.Object,
-                                                 mockQuestionModelValidator.Object);
+                                                 mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         var questionPage = new DropdownQuestionPage
                            {

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Helpers/PlaceholderUpdaterTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Helpers/PlaceholderUpdaterTests.cs
@@ -1,5 +1,7 @@
 using Dfe.EarlyYearsQualification.Web.Helpers;
+using Dfe.EarlyYearsQualification.Web.Services.DatesAndTimes;
 using FluentAssertions;
+using Moq;
 
 namespace Dfe.EarlyYearsQualification.UnitTests.Helpers;
 
@@ -7,37 +9,53 @@ namespace Dfe.EarlyYearsQualification.UnitTests.Helpers;
 public class PlaceholderUpdaterTests
 {
     [TestMethod]
-    public void Replace_ValueToCheckIsEmptyString_ReturnsEmptyString()
+    public void Replace_TextIsEmptyString_ReturnsEmptyString()
     {
-        var placeholderUpdater = new PlaceholderUpdater();
+        var mockDateTimeAdapter = new Mock<IDateTimeAdapter>();
+        var placeholderUpdater = new PlaceholderUpdater(mockDateTimeAdapter.Object);
         var result = placeholderUpdater.Replace(string.Empty);
         result.Should().BeEmpty();
     }
     
     [TestMethod]
-    public void Replace_ValueToCheckIsNull_ReturnsNullString()
+    public void Replace_TextIsNull_ReturnsNullString()
     {
-        var placeholderUpdater = new PlaceholderUpdater();
+        var mockDateTimeAdapter = new Mock<IDateTimeAdapter>();
+        var placeholderUpdater = new PlaceholderUpdater(mockDateTimeAdapter.Object);
         var result = placeholderUpdater.Replace(null!);
         result.Should().BeNull();
     }
     
     [TestMethod]
-    public void Replace_ValueToCheckContainsNoPlaceholders_ReturnsString()
+    public void Replace_TextContainsNoPlaceholders_ReturnsString()
     {
-        var placeholderUpdater = new PlaceholderUpdater();
-        const string valueToCheck = "This contains no placeholders";
-        var result = placeholderUpdater.Replace(valueToCheck);
-        result.Should().Match(valueToCheck);
+        var mockDateTimeAdapter = new Mock<IDateTimeAdapter>();
+        mockDateTimeAdapter.Setup(x => x.Now()).Returns(new DateTime(2024, 11, 01));
+        var placeholderUpdater = new PlaceholderUpdater(mockDateTimeAdapter.Object);
+        const string text = "This contains no placeholders";
+        var result = placeholderUpdater.Replace(text);
+        result.Should().Match(text);
     }
     
     [TestMethod]
-    public void Replace_ValueToCheckContainsActualYearPlaceholder_ReturnsString()
+    public void Replace_TextContainsActualYearPlaceholder_ReturnsString()
     {
-        var placeholderUpdater = new PlaceholderUpdater();
-        const string valueToCheck = "The year is $[actual-year]$";
-        var result = placeholderUpdater.Replace(valueToCheck);
-        var expectedResult = $"The year is {DateTimeOffset.Now.Year}"; 
-        result.Should().Match(expectedResult);
+        var mockDateTimeAdapter = new Mock<IDateTimeAdapter>();
+        mockDateTimeAdapter.Setup(x => x.Now()).Returns(new DateTime(2024, 11, 01));
+        var placeholderUpdater = new PlaceholderUpdater(mockDateTimeAdapter.Object);
+        const string text = "The year is $[actual-year]$";
+        var result = placeholderUpdater.Replace(text);
+        result.Should().Match("The year is 2024");
+    }
+    
+    [TestMethod]
+    public void Replace_TextContainsMultiplePlaceholders_ReturnsString()
+    {
+        var mockDateTimeAdapter = new Mock<IDateTimeAdapter>();
+        mockDateTimeAdapter.Setup(x => x.Now()).Returns(new DateTime(2024, 11, 01));
+        var placeholderUpdater = new PlaceholderUpdater(mockDateTimeAdapter.Object);
+        const string text = "Year is $[actual-year]$ and year again is $[actual-year]$";
+        var result = placeholderUpdater.Replace(text);
+        result.Should().Match("Year is 2024 and year again is 2024");
     }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Helpers/PlaceholderUpdaterTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Helpers/PlaceholderUpdaterTests.cs
@@ -1,0 +1,43 @@
+using Dfe.EarlyYearsQualification.Web.Helpers;
+using FluentAssertions;
+
+namespace Dfe.EarlyYearsQualification.UnitTests.Helpers;
+
+[TestClass]
+public class PlaceholderUpdaterTests
+{
+    [TestMethod]
+    public void Replace_ValueToCheckIsEmptyString_ReturnsEmptyString()
+    {
+        var placeholderUpdater = new PlaceholderUpdater();
+        var result = placeholderUpdater.Replace(string.Empty);
+        result.Should().BeEmpty();
+    }
+    
+    [TestMethod]
+    public void Replace_ValueToCheckIsNull_ReturnsNullString()
+    {
+        var placeholderUpdater = new PlaceholderUpdater();
+        var result = placeholderUpdater.Replace(null!);
+        result.Should().BeNull();
+    }
+    
+    [TestMethod]
+    public void Replace_ValueToCheckContainsNoPlaceholders_ReturnsString()
+    {
+        var placeholderUpdater = new PlaceholderUpdater();
+        const string valueToCheck = "This contains no placeholders";
+        var result = placeholderUpdater.Replace(valueToCheck);
+        result.Should().Match(valueToCheck);
+    }
+    
+    [TestMethod]
+    public void Replace_ValueToCheckContainsActualYearPlaceholder_ReturnsString()
+    {
+        var placeholderUpdater = new PlaceholderUpdater();
+        const string valueToCheck = "The year is $[actual-year]$";
+        var result = placeholderUpdater.Replace(valueToCheck);
+        var expectedResult = $"The year is {DateTimeOffset.Now.Year}"; 
+        result.Should().Match(expectedResult);
+    }
+}

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
@@ -359,6 +359,10 @@ public class MockContentfulServiceTests
         result.MonthLabel.Should().Be("Test Month Label");
         result.YearLabel.Should().Be("Test Year Label");
         result.QuestionHint.Should().Be("Test Question Hint");
+        result.FutureDateErrorMessage.Should().Be("Future date error message");
+        result.FutureDateErrorBannerLinkText.Should().Be("Future date error message banner link");
+        result.IncorrectFormatErrorMessage.Should().Be("Incorrect format error message banner link");
+        result.IncorrectFormatErrorBannerLinkText.Should().Be("Enter a month between 1 and 12 and a year between 1900 and $[actual-year]$");
     }
 
     [TestMethod]

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/DateQuestionModelValidatorTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/DateQuestionModelValidatorTests.cs
@@ -1,3 +1,4 @@
+using Dfe.EarlyYearsQualification.Content.Entities;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
 using Dfe.EarlyYearsQualification.Web.Services.DatesAndTimes;
@@ -18,8 +19,10 @@ public class DateQuestionModelValidatorTests
         var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
 
         var model = new DateQuestionModel { SelectedMonth = 5, SelectedYear = 2023 };
+        var questionPage = new DateQuestionPage();
 
-        validator.IsValid(model).Should().BeTrue();
+        var result = validator.IsValid(model, questionPage);
+        result.IsValid.Should().BeTrue();
     }
 
     [TestMethod]
@@ -36,7 +39,10 @@ public class DateQuestionModelValidatorTests
 
         var model = new DateQuestionModel { SelectedMonth = thisMonth, SelectedYear = thisYear };
 
-        validator.IsValid(model).Should().BeTrue();
+        var questionPage = new DateQuestionPage();
+
+        var result = validator.IsValid(model, questionPage);
+        result.IsValid.Should().BeTrue();
     }
 
     [TestMethod]
@@ -53,7 +59,10 @@ public class DateQuestionModelValidatorTests
 
         var model = new DateQuestionModel { SelectedMonth = thisMonth, SelectedYear = thisYear };
 
-        validator.IsValid(model).Should().BeTrue();
+        var questionPage = new DateQuestionPage();
+
+        var result = validator.IsValid(model, questionPage);
+        result.IsValid.Should().BeTrue();
     }
 
     [TestMethod]
@@ -70,7 +79,10 @@ public class DateQuestionModelValidatorTests
 
         var model = new DateQuestionModel { SelectedMonth = thisMonth + 1, SelectedYear = thisYear };
 
-        validator.IsValid(model).Should().BeFalse();
+        var questionPage = new DateQuestionPage();
+
+        var result = validator.IsValid(model, questionPage);
+        result.IsValid.Should().BeFalse();
     }
 
     [TestMethod]
@@ -83,7 +95,16 @@ public class DateQuestionModelValidatorTests
 
         var model = new DateQuestionModel { SelectedMonth = 5, SelectedYear = 2023 };
 
-        validator.IsValid(model).Should().BeFalse();
+        var questionPage = new DateQuestionPage
+                           {
+                               FutureDateErrorMessage = "Future date error message",
+                               FutureDateErrorBannerLinkText = "Future date banner link text"
+                           };
+
+        var result = validator.IsValid(model, questionPage);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Match(questionPage.FutureDateErrorMessage);
+        result.BannerErrorMessage.Should().Match(questionPage.FutureDateErrorBannerLinkText);
     }
 
     [TestMethod]
@@ -95,7 +116,16 @@ public class DateQuestionModelValidatorTests
 
         var model = new DateQuestionModel { SelectedMonth = 12, SelectedYear = 1899 };
 
-        validator.IsValid(model).Should().BeFalse();
+        var questionPage = new DateQuestionPage
+                           {
+                               IncorrectFormatErrorMessage = "Incorrect format error message",
+                               IncorrectFormatErrorBannerLinkText = "Incorrect format banner link text"
+                           };
+
+        var result = validator.IsValid(model, questionPage);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Match(questionPage.IncorrectFormatErrorMessage);
+        result.BannerErrorMessage.Should().Match(questionPage.IncorrectFormatErrorBannerLinkText);
     }
 
     [TestMethod]
@@ -107,7 +137,16 @@ public class DateQuestionModelValidatorTests
 
         var model = new DateQuestionModel { SelectedMonth = 0, SelectedYear = 2024 };
 
-        validator.IsValid(model).Should().BeFalse();
+        var questionPage = new DateQuestionPage
+                           {
+                               IncorrectFormatErrorMessage = "Incorrect format error message",
+                               IncorrectFormatErrorBannerLinkText = "Incorrect format banner link text"
+                           };
+
+        var result = validator.IsValid(model, questionPage);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Match(questionPage.IncorrectFormatErrorMessage);
+        result.BannerErrorMessage.Should().Match(questionPage.IncorrectFormatErrorBannerLinkText);
     }
 
     [TestMethod]
@@ -119,6 +158,36 @@ public class DateQuestionModelValidatorTests
 
         var model = new DateQuestionModel { SelectedMonth = 13, SelectedYear = 2024 };
 
-        validator.IsValid(model).Should().BeFalse();
+        var questionPage = new DateQuestionPage
+                           {
+                               IncorrectFormatErrorMessage = "Incorrect format error message",
+                               IncorrectFormatErrorBannerLinkText = "Incorrect format banner link text"
+                           };
+
+        var result = validator.IsValid(model, questionPage);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Match(questionPage.IncorrectFormatErrorMessage);
+        result.BannerErrorMessage.Should().Match(questionPage.IncorrectFormatErrorBannerLinkText);
+    }
+    
+    [TestMethod]
+    public void DateQuestionModelValidator_GivenMonthAndYearAre0_ValidatesFalse()
+    {
+        var dateTimeAdapter = new Mock<IDateTimeAdapter>();
+
+        var validator = new DateQuestionModelValidator(dateTimeAdapter.Object);
+
+        var model = new DateQuestionModel { SelectedMonth = 0, SelectedYear = 0 };
+
+        var questionPage = new DateQuestionPage
+                           {
+                               ErrorMessage = "Generic error message",
+                               ErrorBannerLinkText = "Generic banner link text"
+                           };
+
+        var result = validator.IsValid(model, questionPage);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Match(questionPage.ErrorMessage);
+        result.BannerErrorMessage.Should().Match(questionPage.ErrorBannerLinkText);
     }
 }


### PR DESCRIPTION
# Description

Updated logic to add in new error messages for the When was the qualification started page

## Ticket number (if applicable) - EYQB-500

# How Has This Been Tested?

Running locally, unit tests and e2e tests

# Screenshots

![image](https://github.com/user-attachments/assets/16c7018b-46e6-4541-9a04-143093bed7e5)

![image](https://github.com/user-attachments/assets/4c5cf34b-8757-4fd4-8f62-2cf795cad683)

![image](https://github.com/user-attachments/assets/e891d0e2-d6ad-4706-b866-c5277a0b60dc)

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules