### PR TITLE
EYQB-516: Added new cookie builder to always set the secure flag

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Helpers/AntiForgeryCookieBuilder.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Helpers/AntiForgeryCookieBuilder.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Dfe.EarlyYearsQualification.Web.Helpers;
 
-[ExcludeFromCodeCoverage]
 public class AntiForgeryCookieBuilder : CookieBuilder
 {
     public override CookieOptions Build(HttpContext context, DateTimeOffset expiresFrom)

--- a/src/Dfe.EarlyYearsQualification.Web/Helpers/AntiForgeryCookieBuilder.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Helpers/AntiForgeryCookieBuilder.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Dfe.EarlyYearsQualification.Web.Helpers;
+
+[ExcludeFromCodeCoverage]
+public class AntiForgeryCookieBuilder : CookieBuilder
+{
+    public override CookieOptions Build(HttpContext context, DateTimeOffset expiresFrom)
+    {
+        var cookieOptions = base.Build(context, expiresFrom);
+        cookieOptions.Secure = true;
+        return cookieOptions;
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Program.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Program.cs
@@ -36,10 +36,18 @@ if (!useMockContentful)
 }
 
 // Add services to the container.
-builder.Services.AddAntiforgery(options => options.Cookie.SecurePolicy =
-                                               builder.Environment.IsDevelopment() || useMockContentful
-                                                   ? CookieSecurePolicy.SameAsRequest
-                                                   : CookieSecurePolicy.Always);
+builder.Services.AddAntiforgery(options =>
+                                {
+                                    options.Cookie = new AntiForgeryCookieBuilder
+                                                     {
+                                                         Name = ".AspNetCore.Antiforgery",
+                                                         SameSite = SameSiteMode.Strict,
+                                                         HttpOnly = true,
+                                                         IsEssential = true,
+                                                         SecurePolicy = CookieSecurePolicy.None
+                                                     };
+                                });
+
 builder.Services.AddControllersWithViews(options =>
                                          {
                                              // Ensures that all POST actions are protected by default.

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Helpers/AntiForgeryCookieBuilderTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Helpers/AntiForgeryCookieBuilderTests.cs
@@ -1,0 +1,25 @@
+using Dfe.EarlyYearsQualification.Web.Helpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+
+namespace Dfe.EarlyYearsQualification.UnitTests.Helpers;
+
+[TestClass]
+public class AntiForgeryCookieBuilderTests
+{
+    [TestMethod]
+    public void Build_PassInContext_SecureFlagIsTrue()
+    {
+        var builder = new AntiForgeryCookieBuilder
+                      {
+                          Name = ".AspNetCore.Antiforgery",
+                          SameSite = SameSiteMode.Strict,
+                          HttpOnly = true,
+                          IsEssential = true,
+                          SecurePolicy = CookieSecurePolicy.None
+                      };
+
+        var result = builder.Build(new DefaultHttpContext(), DateTimeOffset.Now);
+        result.Secure.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
# Description

Added new cookie builder to always set the secure flag on anti forgery token

## Ticket number (if applicable) - EYQB-516

# How Has This Been Tested?

Running locally

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules