### PR TITLE
Back button behaviour tweaks

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Content/Entities/NavigationLink.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/NavigationLink.cs
@@ -17,7 +17,7 @@ public class NavigationLink
     /// <summary>
     ///     Href value (i.e. <a href="{Href}"></a>)
     /// </summary>
-    public string Href { get; init; } = null!;
+    public string Href { get; set; } = null!;
 
     /// <summary>
     ///     Should this link open in a new tab?

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QualificationDetailsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QualificationDetailsController.cs
@@ -338,7 +338,8 @@ public class QualificationDetailsController(
         Qualification qualification,
         DetailsPage content)
     {
-        var backNavLink = CalculateBackButton(qualificationStartedBeforeSeptember2014, content);
+        var backNavLink = CalculateBackButton(qualificationStartedBeforeSeptember2014,
+                                              content, qualification.QualificationId);
 
         return new QualificationDetailsModel
                {
@@ -379,11 +380,12 @@ public class QualificationDetailsController(
 
     private NavigationLink? CalculateBackButton(
         bool qualificationStartedBeforeSeptember2014,
-        DetailsPage content)
+        DetailsPage content,
+        string qualificationId)
     {
         if (userJourneyCookieService.UserHasAnsweredAdditionalQuestions())
         {
-            return content.BackToAdditionalQuestionsLink ?? content.BackButton;
+            return ContentBackButtonLinkForAdditionalQuestions(content, qualificationId);
         }
 
         var level = userJourneyCookieService.GetLevelOfQualification();
@@ -400,6 +402,24 @@ public class QualificationDetailsController(
                 : content.BackToLevelSixAdvice;
 
         return result ?? content.BackButton;
+    }
+
+    private static NavigationLink? ContentBackButtonLinkForAdditionalQuestions(
+        DetailsPage content, string qualificationId)
+    {
+        var link = content.BackToAdditionalQuestionsLink;
+
+        if (link == null)
+        {
+            return content.BackButton;
+        }
+
+        if (!link.Href.EndsWith($"/{qualificationId}", StringComparison.OrdinalIgnoreCase))
+        {
+            link.Href = $"{link.Href}/{qualificationId}";
+        }
+
+        return link;
     }
 
     private List<AdditionalRequirementAnswerModel>? MapAdditionalRequirementAnswers(

--- a/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/IUserJourneyCookieService.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/IUserJourneyCookieService.cs
@@ -8,7 +8,8 @@ public interface IUserJourneyCookieService
     public void SetWhenWasQualificationStarted(string date);
     public void SetLevelOfQualification(string level);
     public void SetAwardingOrganisation(string awardingOrganisation);
-    public void SetAdditionalQuestionsAnswers(Dictionary<string, string> additionalQuestionsAnswers);
+    public void SetAdditionalQuestionsAnswers(IDictionary<string, string> additionalQuestionsAnswers);
+    public void ClearAdditionalQuestionsAnswers();
 
     public void SetQualificationNameSearchCriteria(string searchCriteria);
     public UserJourneyModel GetUserJourneyModelFromCookie();

--- a/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/UserJourneyCookieService.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/UserJourneyCookieService.cs
@@ -56,18 +56,17 @@ public class UserJourneyCookieService(ICookieManager cookieManager, ILogger<User
     ///     Replaces all the existing question answers in the user journey with <paramref name="additionalQuestionsAnswers" />
     /// </summary>
     /// <param name="additionalQuestionsAnswers"></param>
-    public void SetAdditionalQuestionsAnswers(Dictionary<string, string> additionalQuestionsAnswers)
+    public void SetAdditionalQuestionsAnswers(IDictionary<string, string> additionalQuestionsAnswers)
     {
-        var model = GetUserJourneyModelFromCookie();
+        SetAdditionalQuestionsAnswersInternal(additionalQuestionsAnswers);
+    }
 
-        model.AdditionalQuestionsAnswers.Clear();
-
-        foreach (var answer in additionalQuestionsAnswers)
-        {
-            model.AdditionalQuestionsAnswers[answer.Key] = answer.Value;
-        }
-
-        SetJourneyCookie(model);
+    /// <summary>
+    ///     Removes existing question answers in the user journey
+    /// </summary>
+    public void ClearAdditionalQuestionsAnswers()
+    {
+        SetAdditionalQuestionsAnswersInternal([]);
     }
 
     public void SetQualificationNameSearchCriteria(string searchCriteria)
@@ -220,6 +219,21 @@ public class UserJourneyCookieService(ICookieManager cookieManager, ILogger<User
     {
         var cookie = GetUserJourneyModelFromCookie();
         return cookie.AdditionalQuestionsAnswers.Count > 0;
+    }
+
+    private void SetAdditionalQuestionsAnswersInternal(
+        IEnumerable<KeyValuePair<string, string>> additionalQuestionsAnswers)
+    {
+        var model = GetUserJourneyModelFromCookie();
+
+        model.AdditionalQuestionsAnswers.Clear();
+
+        foreach (var answer in additionalQuestionsAnswers)
+        {
+            model.AdditionalQuestionsAnswers[answer.Key] = answer.Value;
+        }
+
+        SetJourneyCookie(model);
     }
 
     private void SetJourneyCookie(UserJourneyModel model)

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/ConfirmQualificationControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/ConfirmQualificationControllerTests.cs
@@ -4,6 +4,7 @@ using Dfe.EarlyYearsQualification.Content.Services;
 using Dfe.EarlyYearsQualification.UnitTests.Extensions;
 using Dfe.EarlyYearsQualification.Web.Controllers;
 using Dfe.EarlyYearsQualification.Web.Models.Content;
+using Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -21,8 +22,11 @@ public class ConfirmQualificationControllerTests
     {
         var mockLogger = new Mock<ILogger<ConfirmQualificationController>>();
         var mockContentService = new Mock<IContentService>();
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         var result = await controller.Index(id);
 
@@ -36,9 +40,14 @@ public class ConfirmQualificationControllerTests
         var mockLogger = new Mock<ILogger<ConfirmQualificationController>>();
         var mockContentService = new Mock<IContentService>();
 
-        mockContentService.Setup(x => x.GetConfirmQualificationPage()).ReturnsAsync(default(ConfirmQualificationPage?));
+        mockContentService.Setup(x => x.GetConfirmQualificationPage())
+                          .ReturnsAsync(default(ConfirmQualificationPage?));
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         var result = await controller.Index("Some ID");
 
@@ -59,41 +68,46 @@ public class ConfirmQualificationControllerTests
         var mockContentService = new Mock<IContentService>();
 
         mockContentService.Setup(x => x.GetConfirmQualificationPage()).ReturnsAsync(new ConfirmQualificationPage
-            {
-                QualificationLabel = "Test qualification label",
-                BackButton = new NavigationLink
-                             {
-                                 DisplayText = "Test back button",
-                                 OpenInNewTab = false,
-                                 Href = "/qualifications"
-                             },
-                ErrorText = "Test error text",
-                ButtonText = "Test button text",
-                LevelLabel = "Test level label",
-                DateAddedLabel = "Test date added label",
-                Heading = "Test heading",
-                Options =
-                [
-                    new Option
-                    {
-                        Label = "yes",
-                        Value = "yes"
-                    },
-                    new Option
-                    {
-                        Label = "no",
-                        Value = "no"
-                    }
-                ],
-                RadioHeading = "Test radio heading",
-                AwardingOrganisationLabel = "Test awarding organisation label",
-                ErrorBannerHeading = "Test error banner heading",
-                ErrorBannerLink = "Test error banner link"
-            });
+                 {
+                     QualificationLabel = "Test qualification label",
+                     BackButton = new NavigationLink
+                                  {
+                                      DisplayText = "Test back button",
+                                      OpenInNewTab = false,
+                                      Href = "/qualifications"
+                                  },
+                     ErrorText = "Test error text",
+                     ButtonText = "Test button text",
+                     LevelLabel = "Test level label",
+                     DateAddedLabel = "Test date added label",
+                     Heading = "Test heading",
+                     Options =
+                     [
+                         new Option
+                         {
+                             Label = "yes",
+                             Value = "yes"
+                         },
+                         new Option
+                         {
+                             Label = "no",
+                             Value = "no"
+                         }
+                     ],
+                     RadioHeading = "Test radio heading",
+                     AwardingOrganisationLabel = "Test awarding organisation label",
+                     ErrorBannerHeading = "Test error banner heading",
+                     ErrorBannerLink = "Test error banner link"
+                 });
 
-        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(default(Qualification?));
+        mockContentService.Setup(x => x.GetQualificationById("Some ID"))
+                          .ReturnsAsync(default(Qualification?));
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         var result = await controller.Index("Some ID");
 
@@ -114,37 +128,37 @@ public class ConfirmQualificationControllerTests
         var mockContentService = new Mock<IContentService>();
 
         mockContentService.Setup(x => x.GetConfirmQualificationPage()).ReturnsAsync(new ConfirmQualificationPage
-            {
-                QualificationLabel = "Test qualification label",
-                BackButton = new NavigationLink
-                             {
-                                 DisplayText = "Test back button",
-                                 OpenInNewTab = false,
-                                 Href = "/qualifications"
-                             },
-                ErrorText = "Test error text",
-                ButtonText = "Test button text",
-                LevelLabel = "Test level label",
-                DateAddedLabel = "Test date added label",
-                Heading = "Test heading",
-                Options =
-                [
-                    new Option
-                    {
-                        Label = "yes",
-                        Value = "yes"
-                    },
-                    new Option
-                    {
-                        Label = "no",
-                        Value = "no"
-                    }
-                ],
-                RadioHeading = "Test radio heading",
-                AwardingOrganisationLabel = "Test awarding organisation label",
-                ErrorBannerHeading = "Test error banner heading",
-                ErrorBannerLink = "Test error banner link"
-            });
+                 {
+                     QualificationLabel = "Test qualification label",
+                     BackButton = new NavigationLink
+                                  {
+                                      DisplayText = "Test back button",
+                                      OpenInNewTab = false,
+                                      Href = "/qualifications"
+                                  },
+                     ErrorText = "Test error text",
+                     ButtonText = "Test button text",
+                     LevelLabel = "Test level label",
+                     DateAddedLabel = "Test date added label",
+                     Heading = "Test heading",
+                     Options =
+                     [
+                         new Option
+                         {
+                             Label = "yes",
+                             Value = "yes"
+                         },
+                         new Option
+                         {
+                             Label = "no",
+                             Value = "no"
+                         }
+                     ],
+                     RadioHeading = "Test radio heading",
+                     AwardingOrganisationLabel = "Test awarding organisation label",
+                     ErrorBannerHeading = "Test error banner heading",
+                     ErrorBannerLink = "Test error banner link"
+                 });
 
         var qualification = new Qualification("Some ID",
                                               "Qualification Name",
@@ -156,9 +170,14 @@ public class ConfirmQualificationControllerTests
                                 AdditionalRequirements = "additional requirements"
                             };
 
-        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(qualification);
+        mockContentService.Setup(x => x.GetQualificationById("Some ID"))
+                          .ReturnsAsync(qualification);
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         var result = await controller.Index("Some ID");
 
@@ -224,9 +243,14 @@ public class ConfirmQualificationControllerTests
                                 QualificationNumber = "ABC/547/900",
                                 AdditionalRequirements = "additional requirements"
                             };
-        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(qualification);
+        mockContentService.Setup(x => x.GetQualificationById("Some ID"))
+                          .ReturnsAsync(qualification);
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         controller.ModelState.AddModelError("test", "error");
 
@@ -247,8 +271,11 @@ public class ConfirmQualificationControllerTests
     {
         var mockLogger = new Mock<ILogger<ConfirmQualificationController>>();
         var mockContentService = new Mock<IContentService>();
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         var result = await controller.Confirm(new ConfirmQualificationPageModel());
 
@@ -268,9 +295,14 @@ public class ConfirmQualificationControllerTests
         var mockLogger = new Mock<ILogger<ConfirmQualificationController>>();
         var mockContentService = new Mock<IContentService>();
 
-        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(default(Qualification?));
+        mockContentService.Setup(x => x.GetQualificationById("Some ID"))
+                          .ReturnsAsync(default(Qualification?));
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         controller.ModelState.AddModelError("test", "error");
 
@@ -296,37 +328,37 @@ public class ConfirmQualificationControllerTests
         var mockContentService = new Mock<IContentService>();
 
         mockContentService.Setup(x => x.GetConfirmQualificationPage()).ReturnsAsync(new ConfirmQualificationPage
-            {
-                QualificationLabel = "Test qualification label",
-                BackButton = new NavigationLink
-                             {
-                                 DisplayText = "Test back button",
-                                 OpenInNewTab = false,
-                                 Href = "/qualifications"
-                             },
-                ErrorText = "Test error text",
-                ButtonText = "Test button text",
-                LevelLabel = "Test level label",
-                DateAddedLabel = "Test date added label",
-                Heading = "Test heading",
-                Options =
-                [
-                    new Option
-                    {
-                        Label = "yes",
-                        Value = "yes"
-                    },
-                    new Option
-                    {
-                        Label = "no",
-                        Value = "no"
-                    }
-                ],
-                RadioHeading = "Test radio heading",
-                AwardingOrganisationLabel = "Test awarding organisation label",
-                ErrorBannerHeading = "Test error banner heading",
-                ErrorBannerLink = "Test error banner link"
-            });
+                 {
+                     QualificationLabel = "Test qualification label",
+                     BackButton = new NavigationLink
+                                  {
+                                      DisplayText = "Test back button",
+                                      OpenInNewTab = false,
+                                      Href = "/qualifications"
+                                  },
+                     ErrorText = "Test error text",
+                     ButtonText = "Test button text",
+                     LevelLabel = "Test level label",
+                     DateAddedLabel = "Test date added label",
+                     Heading = "Test heading",
+                     Options =
+                     [
+                         new Option
+                         {
+                             Label = "yes",
+                             Value = "yes"
+                         },
+                         new Option
+                         {
+                             Label = "no",
+                             Value = "no"
+                         }
+                     ],
+                     RadioHeading = "Test radio heading",
+                     AwardingOrganisationLabel = "Test awarding organisation label",
+                     ErrorBannerHeading = "Test error banner heading",
+                     ErrorBannerLink = "Test error banner link"
+                 });
 
         var qualification = new Qualification("Some ID",
                                               "Qualification Name",
@@ -337,9 +369,15 @@ public class ConfirmQualificationControllerTests
                                 QualificationNumber = "ABC/547/900",
                                 AdditionalRequirements = "additional requirements"
                             };
-        mockContentService.Setup(x => x.GetQualificationById("Some ID")).ReturnsAsync(qualification);
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        mockContentService.Setup(x => x.GetQualificationById("Some ID"))
+                          .ReturnsAsync(qualification);
+
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         controller.ModelState.AddModelError("test", "error");
 
@@ -411,9 +449,15 @@ public class ConfirmQualificationControllerTests
                                 AdditionalRequirements = "additional requirements",
                                 AdditionalRequirementQuestions = additionalRequirements
                             };
-        mockContentService.Setup(x => x.GetQualificationById("TEST-123")).ReturnsAsync(qualification);
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        mockContentService.Setup(x => x.GetQualificationById("TEST-123"))
+                          .ReturnsAsync(qualification);
+
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         var result = await controller.Confirm(new ConfirmQualificationPageModel
                                               {
@@ -445,9 +489,14 @@ public class ConfirmQualificationControllerTests
                                 QualificationNumber = "ABC/547/900",
                                 AdditionalRequirements = "additional requirements"
                             };
-        mockContentService.Setup(x => x.GetQualificationById("TEST-123")).ReturnsAsync(qualification);
+        mockContentService.Setup(x => x.GetQualificationById("TEST-123"))
+                          .ReturnsAsync(qualification);
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         var result = await controller.Confirm(new ConfirmQualificationPageModel
                                               {
@@ -479,9 +528,15 @@ public class ConfirmQualificationControllerTests
                                 QualificationNumber = "ABC/547/900",
                                 AdditionalRequirements = "additional requirements"
                             };
-        mockContentService.Setup(x => x.GetQualificationById("TEST-123")).ReturnsAsync(qualification);
 
-        var controller = new ConfirmQualificationController(mockLogger.Object, mockContentService.Object);
+        mockContentService.Setup(x => x.GetQualificationById("TEST-123"))
+                          .ReturnsAsync(qualification);
+
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
 
         var result = await controller.Confirm(new ConfirmQualificationPageModel
                                               {
@@ -495,5 +550,39 @@ public class ConfirmQualificationControllerTests
 
         actionResult.ActionName.Should().Be("Get");
         actionResult.ControllerName.Should().Be("QualificationDetails");
+    }
+
+    [TestMethod]
+    public async Task Post_ValidModel_ClearsUserJourneyAdditionalAnswers()
+    {
+        var mockLogger = new Mock<ILogger<ConfirmQualificationController>>();
+        var mockContentService = new Mock<IContentService>();
+
+        var qualification = new Qualification("Some ID",
+                                              "Qualification Name",
+                                              AwardingOrganisations.Ncfe,
+                                              2)
+                            {
+                                FromWhichYear = "2014", ToWhichYear = "2019",
+                                QualificationNumber = "ABC/547/900",
+                                AdditionalRequirements = "additional requirements"
+                            };
+
+        mockContentService.Setup(x => x.GetQualificationById("TEST-123"))
+                          .ReturnsAsync(qualification);
+
+        var mockUserJourneyService = new Mock<IUserJourneyCookieService>();
+
+        var controller =
+            new ConfirmQualificationController(mockLogger.Object, mockContentService.Object,
+                                               mockUserJourneyService.Object);
+
+        await controller.Confirm(new ConfirmQualificationPageModel
+                                 {
+                                     QualificationId = "TEST-123",
+                                     ConfirmQualificationAnswer = "yes"
+                                 });
+
+        mockUserJourneyService.Verify(x => x.ClearAdditionalQuestionsAnswers(), Times.Once);
     }
 }


### PR DESCRIPTION
# Description

Link back to additional questions requires qualification ID in URL.
Clear additional answers in user journey cookie when confirming a qualification selection.

## Ticket number (if applicable)

EYQB-487

# How Has This Been Tested?

Tested locally, new unit tests. 

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules