### PR TITLE
EYQB-487. Remember whether user selected the qual from the list.

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/AdviceController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/AdviceController.cs
@@ -5,14 +5,30 @@ using Dfe.EarlyYearsQualification.Content.Services;
 using Dfe.EarlyYearsQualification.Web.Attributes;
 using Dfe.EarlyYearsQualification.Web.Controllers.Base;
 using Dfe.EarlyYearsQualification.Web.Models.Content;
+using Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Dfe.EarlyYearsQualification.Web.Controllers;
 
 [Route("/advice")]
-public class AdviceController(ILogger<AdviceController> logger, IContentService contentService, IHtmlRenderer renderer)
+public class AdviceController(
+    ILogger<AdviceController> logger,
+    IContentService contentService,
+    IHtmlRenderer renderer,
+    IUserJourneyCookieService userJourneyCookieService)
     : ServiceController
 {
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        // user has landed on an Advice page, so is not going to select a qualification from the list,
+        // partly determines where the back button should go when displaying qualification details
+        userJourneyCookieService.SetUserSelectedQualificationFromList(YesOrNo.No);
+        userJourneyCookieService.ClearAdditionalQuestionsAnswers();
+
+        base.OnActionExecuting(context);
+    }
+
     [HttpGet("qualification-outside-the-united-kingdom")]
     public async Task<IActionResult> QualificationOutsideTheUnitedKingdom()
     {
@@ -49,14 +65,14 @@ public class AdviceController(ILogger<AdviceController> logger, IContentService 
     {
         return await GetView(AdvicePages.QualificationNotOnTheList);
     }
-    
+
     [HttpGet("level-6-qualification-pre-2014")]
     [RedirectIfDateMissing]
     public async Task<IActionResult> Level6QualificationPre2014()
     {
         return await GetView(AdvicePages.Level6QualificationPre2014);
     }
-    
+
     [HttpGet("level-6-qualification-post-2014")]
     [RedirectIfDateMissing]
     public async Task<IActionResult> Level6QualificationPost2014()

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/ConfirmQualificationController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/ConfirmQualificationController.cs
@@ -70,6 +70,7 @@ public class ConfirmQualificationController(
 
         if (ModelState.IsValid)
         {
+            userJourneyCookieService.SetUserSelectedQualificationFromList(YesOrNo.Yes);
             userJourneyCookieService.ClearAdditionalQuestionsAnswers();
 
             var hasAdditionalQuestions = qualification.AdditionalRequirementQuestions is not null &&

--- a/src/Dfe.EarlyYearsQualification.Web/Models/UserJourneyModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/UserJourneyModel.cs
@@ -1,3 +1,5 @@
+using Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
+
 namespace Dfe.EarlyYearsQualification.Web.Models;
 
 public class UserJourneyModel
@@ -10,4 +12,5 @@ public class UserJourneyModel
     public string SearchCriteria { get; set; } = string.Empty;
 
     public Dictionary<string, string> AdditionalQuestionsAnswers { get; init; } = new();
+    public YesOrNo QualificationWasSelectedFromList { get; set; }
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/IUserJourneyCookieService.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/IUserJourneyCookieService.cs
@@ -8,6 +8,8 @@ public interface IUserJourneyCookieService
     public void SetWhenWasQualificationStarted(string date);
     public void SetLevelOfQualification(string level);
     public void SetAwardingOrganisation(string awardingOrganisation);
+    public void SetUserSelectedQualificationFromList(YesOrNo yesOrNo);
+
     public void SetAdditionalQuestionsAnswers(IDictionary<string, string> additionalQuestionsAnswers);
     public void ClearAdditionalQuestionsAnswers();
 
@@ -28,4 +30,5 @@ public interface IUserJourneyCookieService
     public string? GetSearchCriteria();
     public Dictionary<string, string>? GetAdditionalQuestionsAnswers();
     public bool UserHasAnsweredAdditionalQuestions();
+    public YesOrNo GetQualificationWasSelectedFromList();
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/UserJourneyCookieService.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/UserJourneyCookieService.cs
@@ -9,12 +9,12 @@ namespace Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
 public class UserJourneyCookieService(ICookieManager cookieManager, ILogger<UserJourneyCookieService> logger)
     : IUserJourneyCookieService
 {
-    private readonly CookieOptions _options = new()
-                                              {
-                                                  Secure = true,
-                                                  HttpOnly = true,
-                                                  Expires = new DateTimeOffset(DateTime.Now.AddMinutes(30))
-                                              };
+    private readonly CookieOptions _cookieOptions = new()
+                                                    {
+                                                        Secure = true,
+                                                        HttpOnly = true,
+                                                        Expires = new DateTimeOffset(DateTime.Now.AddMinutes(30))
+                                                    };
 
     public void SetWhereWasQualificationAwarded(string location)
     {
@@ -48,6 +48,15 @@ public class UserJourneyCookieService(ICookieManager cookieManager, ILogger<User
         var model = GetUserJourneyModelFromCookie();
 
         model.WhatIsTheAwardingOrganisation = awardingOrganisation;
+
+        SetJourneyCookie(model);
+    }
+
+    public void SetUserSelectedQualificationFromList(YesOrNo yesOrNo)
+    {
+        var model = GetUserJourneyModelFromCookie();
+
+        model.QualificationWasSelectedFromList = yesOrNo;
 
         SetJourneyCookie(model);
     }
@@ -221,6 +230,13 @@ public class UserJourneyCookieService(ICookieManager cookieManager, ILogger<User
         return cookie.AdditionalQuestionsAnswers.Count > 0;
     }
 
+    public YesOrNo GetQualificationWasSelectedFromList()
+    {
+        var model = GetUserJourneyModelFromCookie();
+
+        return model.QualificationWasSelectedFromList;
+    }
+
     private void SetAdditionalQuestionsAnswersInternal(
         IEnumerable<KeyValuePair<string, string>> additionalQuestionsAnswers)
     {
@@ -239,6 +255,6 @@ public class UserJourneyCookieService(ICookieManager cookieManager, ILogger<User
     private void SetJourneyCookie(UserJourneyModel model)
     {
         var serializedCookie = JsonSerializer.Serialize(model);
-        cookieManager.SetOutboundCookie(CookieKeyNames.UserJourneyKey, serializedCookie, _options);
+        cookieManager.SetOutboundCookie(CookieKeyNames.UserJourneyKey, serializedCookie, _cookieOptions);
     }
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/YesOrNo.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/YesOrNo.cs
@@ -1,0 +1,7 @@
+namespace Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
+
+public enum YesOrNo
+{
+    No = 0,
+    Yes = 1
+}

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/AdviceControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/AdviceControllerTests.cs
@@ -7,6 +7,7 @@ using Dfe.EarlyYearsQualification.Mock.Helpers;
 using Dfe.EarlyYearsQualification.UnitTests.Extensions;
 using Dfe.EarlyYearsQualification.Web.Controllers;
 using Dfe.EarlyYearsQualification.Web.Models.Content;
+using Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,8 @@ namespace Dfe.EarlyYearsQualification.UnitTests.Controllers;
 [TestClass]
 public class AdviceControllerTests
 {
+    private static readonly Mock<IUserJourneyCookieService> UserJourneyMockNoOp = new();
+
     [TestMethod]
     public async Task QualificationOutsideTheUnitedKingdom_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
     {
@@ -24,7 +27,10 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object,
+                                              mockContentService.Object,
+                                              mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedOutsideTheUk))
                           .ReturnsAsync((AdvicePage?)default).Verifiable();
@@ -49,7 +55,8 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         var advicePage = new AdvicePage { Heading = "Heading", Body = ContentfulContentHelper.Text("Test html body") };
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedOutsideTheUk))
@@ -81,7 +88,8 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsStartedBetweenSept2014AndAug2019))
                           .ReturnsAsync((AdvicePage?)default).Verifiable();
@@ -107,7 +115,8 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         var advicePage = new AdvicePage { Heading = "Heading", Body = ContentfulContentHelper.Text("Test html body") };
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsStartedBetweenSept2014AndAug2019))
@@ -138,11 +147,12 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInNorthernIreland))
                           .ReturnsAsync((AdvicePage?)default).Verifiable();
-        
+
         var result = await controller.QualificationsAchievedInNorthernIreland();
 
         result.Should().NotBeNull();
@@ -164,7 +174,8 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         var advicePage = new AdvicePage { Heading = "Heading", Body = ContentfulContentHelper.Text("Test html body") };
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInNorthernIreland))
@@ -187,7 +198,7 @@ public class AdviceControllerTests
 
         mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
     }
-    
+
     [TestMethod]
     public async Task QualificationsAchievedInScotland_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
     {
@@ -195,11 +206,12 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInScotland))
                           .ReturnsAsync((AdvicePage?)default).Verifiable();
-        
+
         var result = await controller.QualificationsAchievedInScotland();
 
         result.Should().NotBeNull();
@@ -221,7 +233,8 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         var advicePage = new AdvicePage { Heading = "Heading", Body = ContentfulContentHelper.Text("Test html body") };
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInScotland))
@@ -244,7 +257,7 @@ public class AdviceControllerTests
 
         mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
     }
-    
+
     [TestMethod]
     public async Task QualificationsAchievedInWales_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
     {
@@ -252,11 +265,12 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInWales))
                           .ReturnsAsync((AdvicePage?)default).Verifiable();
-        
+
         var result = await controller.QualificationsAchievedInWales();
 
         result.Should().NotBeNull();
@@ -278,7 +292,8 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         var advicePage = new AdvicePage { Heading = "Heading", Body = ContentfulContentHelper.Text("Test html body") };
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationsAchievedInWales))
@@ -301,7 +316,7 @@ public class AdviceControllerTests
 
         mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
     }
-    
+
     [TestMethod]
     public async Task QualificationNotOnTheList_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
     {
@@ -309,11 +324,12 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationNotOnTheList))
                           .ReturnsAsync((AdvicePage?)default).Verifiable();
-        
+
         var result = await controller.QualificationNotOnTheList();
 
         result.Should().NotBeNull();
@@ -335,7 +351,8 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         var advicePage = new AdvicePage { Heading = "Heading", Body = ContentfulContentHelper.Text("Test html body") };
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationNotOnTheList))
@@ -358,7 +375,7 @@ public class AdviceControllerTests
 
         mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
     }
-     
+
     [TestMethod]
     public async Task QualificationLevel7_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
     {
@@ -366,11 +383,12 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationLevel7))
                           .ReturnsAsync((AdvicePage?)default).Verifiable();
-        
+
         var result = await controller.QualificationLevel7();
 
         result.Should().NotBeNull();
@@ -392,11 +410,13 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
-        var renderedHtmlBody = "Test html body (level 7)";
-        
-        var advicePage = new AdvicePage { Heading = "Heading (level 7)", Body = ContentfulContentHelper.Text("Anything") };
+        const string renderedHtmlBody = "Test html body (level 7)";
+
+        var advicePage = new AdvicePage
+                         { Heading = "Heading (level 7)", Body = ContentfulContentHelper.Text("Anything") };
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.QualificationLevel7))
                           .ReturnsAsync(advicePage);
 
@@ -417,7 +437,7 @@ public class AdviceControllerTests
 
         mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
     }
-    
+
     [TestMethod]
     public async Task Level6QualificationPre2014_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
     {
@@ -425,11 +445,12 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.Level6QualificationPre2014))
                           .ReturnsAsync((AdvicePage?)default).Verifiable();
-        
+
         var result = await controller.Level6QualificationPre2014();
 
         result.Should().NotBeNull();
@@ -451,11 +472,13 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
-        var renderedHtmlBody = "Test html body (level 6 pre 2014)";
-        
-        var advicePage = new AdvicePage { Heading = "Heading (level 6 pre 2014)", Body = ContentfulContentHelper.Text("Anything") };
+        const string renderedHtmlBody = "Test html body (level 6 pre 2014)";
+
+        var advicePage = new AdvicePage
+                         { Heading = "Heading (level 6 pre 2014)", Body = ContentfulContentHelper.Text("Anything") };
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.Level6QualificationPre2014))
                           .ReturnsAsync(advicePage);
 
@@ -476,19 +499,20 @@ public class AdviceControllerTests
 
         mockHtmlRenderer.Verify(x => x.ToHtml(It.IsAny<Document>()), Times.Once);
     }
-    
-        [TestMethod]
+
+    [TestMethod]
     public async Task Level6QualificationPost2014_ContentServiceReturnsNoAdvicePage_RedirectsToErrorPage()
     {
         var mockLogger = new Mock<ILogger<AdviceController>>();
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.Level6QualificationPost2014))
                           .ReturnsAsync((AdvicePage?)default).Verifiable();
-        
+
         var result = await controller.Level6QualificationPost2014();
 
         result.Should().NotBeNull();
@@ -510,11 +534,13 @@ public class AdviceControllerTests
         var mockContentService = new Mock<IContentService>();
         var mockHtmlRenderer = new Mock<IHtmlRenderer>();
 
-        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object);
+        var controller = new AdviceController(mockLogger.Object, mockContentService.Object, mockHtmlRenderer.Object,
+                                              UserJourneyMockNoOp.Object);
 
-        var renderedHtmlBody = "Test html body (level 6 post 2014)";
-        
-        var advicePage = new AdvicePage { Heading = "Heading (level 6 post 2014)", Body = ContentfulContentHelper.Text("Anything") };
+        const string renderedHtmlBody = "Test html body (level 6 post 2014)";
+
+        var advicePage = new AdvicePage
+                         { Heading = "Heading (level 6 post 2014)", Body = ContentfulContentHelper.Text("Anything") };
         mockContentService.Setup(x => x.GetAdvicePage(AdvicePages.Level6QualificationPost2014))
                           .ReturnsAsync(advicePage);
 

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/UserJourneyCookieServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/UserJourneyCookieServiceTests.cs
@@ -26,12 +26,12 @@ public class UserJourneyCookieServiceTests
 
         service.SetWhereWasQualificationAwarded("some test string");
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
-                                                              {
-                                                                  WhereWasQualificationAwarded = "some test string"
-                                                              });
+        var model = new UserJourneyModel
+                    {
+                        WhereWasQualificationAwarded = "some test string"
+                    };
 
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, model);
     }
 
     [TestMethod]
@@ -45,12 +45,12 @@ public class UserJourneyCookieServiceTests
 
         service.SetWhenWasQualificationStarted("some test string");
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
-                                                              {
-                                                                  WhenWasQualificationStarted = "some test string"
-                                                              });
+        var model = new UserJourneyModel
+                    {
+                        WhenWasQualificationStarted = "some test string"
+                    };
 
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, model);
     }
 
     [TestMethod]
@@ -64,12 +64,12 @@ public class UserJourneyCookieServiceTests
 
         service.SetLevelOfQualification("some test string");
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
-                                                              {
-                                                                  LevelOfQualification = "some test string"
-                                                              });
+        var model = new UserJourneyModel
+                    {
+                        LevelOfQualification = "some test string"
+                    };
 
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, model);
     }
 
     [TestMethod]
@@ -83,12 +83,12 @@ public class UserJourneyCookieServiceTests
 
         service.SetAwardingOrganisation("some test string");
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
-                                                              {
-                                                                  WhatIsTheAwardingOrganisation = "some test string"
-                                                              });
+        var model = new UserJourneyModel
+                    {
+                        WhatIsTheAwardingOrganisation = "some test string"
+                    };
 
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, model);
     }
 
     [TestMethod]
@@ -105,8 +105,7 @@ public class UserJourneyCookieServiceTests
         model.WhenWasQualificationStarted.Should().BeEmpty();
         model.WhereWasQualificationAwarded.Should().BeEmpty();
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel());
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, new UserJourneyModel());
     }
 
     [TestMethod]
@@ -144,8 +143,7 @@ public class UserJourneyCookieServiceTests
         model.WhenWasQualificationStarted.Should().BeEmpty();
         model.WhereWasQualificationAwarded.Should().BeEmpty();
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel());
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, new UserJourneyModel());
     }
 
     [TestMethod]
@@ -164,8 +162,7 @@ public class UserJourneyCookieServiceTests
 
         service.SetUserJourneyModelCookie(existingModel);
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(existingModel);
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, existingModel);
     }
 
     [TestMethod]
@@ -178,8 +175,7 @@ public class UserJourneyCookieServiceTests
 
         service.ResetUserJourneyCookie();
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel());
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, new UserJourneyModel());
     }
 
     [TestMethod]
@@ -198,8 +194,7 @@ public class UserJourneyCookieServiceTests
 
         service.ResetUserJourneyCookie();
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel());
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, new UserJourneyModel());
     }
 
     [TestMethod]
@@ -634,12 +629,12 @@ public class UserJourneyCookieServiceTests
         const string searchCriteria = "This is a test";
         service.SetQualificationNameSearchCriteria(searchCriteria);
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
-                                                              {
-                                                                  SearchCriteria = searchCriteria
-                                                              });
+        var model = new UserJourneyModel
+                    {
+                        SearchCriteria = searchCriteria
+                    };
 
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, model);
     }
 
     [TestMethod]
@@ -687,12 +682,12 @@ public class UserJourneyCookieServiceTests
         Dictionary<string, string> dictionary = new() { { "This is a test question", "Answer" } };
         service.SetAdditionalQuestionsAnswers(dictionary);
 
-        var serialisedModelToCheck = JsonSerializer.Serialize(new UserJourneyModel
-                                                              {
-                                                                  AdditionalQuestionsAnswers = dictionary
-                                                              });
+        var model = new UserJourneyModel
+                    {
+                        AdditionalQuestionsAnswers = dictionary
+                    };
 
-        CheckSerializedModelWasSet(mockHttpContextAccessor, serialisedModelToCheck);
+        CheckSerializedModelWasSet(mockHttpContextAccessor, model);
     }
 
     [TestMethod]
@@ -760,6 +755,56 @@ public class UserJourneyCookieServiceTests
         service.UserHasAnsweredAdditionalQuestions().Should().BeTrue();
     }
 
+    [TestMethod]
+    public void SetSelectedFromList_Yes_SetsCookieToYes()
+    {
+        var mockCookieManager = SetCookieManagerWithExistingCookie(new UserJourneyModel());
+
+        var service = new UserJourneyCookieService(mockCookieManager.Object,
+                                                   NullLogger<UserJourneyCookieService>.Instance);
+
+        service.SetUserSelectedQualificationFromList(YesOrNo.Yes);
+
+        CheckSerializedModelWasSet(mockCookieManager, new UserJourneyModel
+                                                      {
+                                                          QualificationWasSelectedFromList = YesOrNo.Yes
+                                                      });
+    }
+
+    [TestMethod]
+    public void SetSelectedFromList_No_SetsCookieToNo()
+    {
+        var mockCookieManager = SetCookieManagerWithExistingCookie(new UserJourneyModel
+                                                                   {
+                                                                       QualificationWasSelectedFromList = YesOrNo.Yes
+                                                                   });
+
+        var service = new UserJourneyCookieService(mockCookieManager.Object,
+                                                   NullLogger<UserJourneyCookieService>.Instance);
+
+        service.SetUserSelectedQualificationFromList(YesOrNo.No);
+
+        CheckSerializedModelWasSet(mockCookieManager, new UserJourneyModel
+                                                      {
+                                                          QualificationWasSelectedFromList = YesOrNo.No
+                                                      });
+    }
+
+    [TestMethod]
+    public void GetSelectedFromList_GetsValueInCookie()
+    {
+        var mockCookieManager = SetCookieManagerWithExistingCookie(new UserJourneyModel
+                                                                   {
+                                                                       QualificationWasSelectedFromList = YesOrNo.Yes
+                                                                   });
+
+        var service = new UserJourneyCookieService(mockCookieManager.Object,
+                                                   NullLogger<UserJourneyCookieService>.Instance);
+
+        var result = service.GetQualificationWasSelectedFromList();
+        result.Should().Be(YesOrNo.Yes);
+    }
+
     private static Mock<ICookieManager> SetCookieManagerWithExistingCookie(object? model)
     {
         var serializedModel = JsonSerializer.Serialize(model);
@@ -784,15 +829,17 @@ public class UserJourneyCookieServiceTests
     }
 
     private static void CheckSerializedModelWasSet(Mock<ICookieManager> mockContext,
-                                                   string serializedModelToCheck)
+                                                   UserJourneyModel expectedModel)
     {
+        var expectedCookieValue = JsonSerializer.Serialize(expectedModel);
+
         var in29Minutes = new DateTimeOffset(DateTime.Now.AddMinutes(29));
         var in30Minutes = new DateTimeOffset(DateTime.Now.AddMinutes(30));
 
         mockContext
             .Verify(m =>
                         m.SetOutboundCookie(CookieKeyNames.UserJourneyKey,
-                                            serializedModelToCheck,
+                                            expectedCookieValue,
                                             It.Is<CookieOptions>(
                                                                  options =>
                                                                      options.Secure


### PR DESCRIPTION
# Description

Record whether the user selected the qualification from the list, so that the back-link address
can be set correctly if they come through Level 6 advice pages.

## Ticket number (if applicable)

EYQB-487

# How Has This Been Tested?

Tested locally; some new unit tests. 

# Screenshots

![image](https://github.com/user-attachments/assets/a0e12912-7bde-4453-86ac-034e9afcb003)

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules