### PR TITLE
EYQB-536: Updated to add in new ratio text when not F&R

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Content/Entities/DetailsPage.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/DetailsPage.cs
@@ -53,4 +53,6 @@ public class DetailsPage
     public string QualificationNameLabel { get; init; } = string.Empty;
 
     public string QualificationStartDateLabel { get; init; } = string.Empty;
+
+    public Document? RatiosTextNotFullAndRelevant { get; init; }
 }

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
@@ -115,6 +115,7 @@ public class MockContentfulService : IContentService
         var checkAnotherQualificationText = ContentfulContentHelper.Paragraph("Test Check Another Qualification Text");
         var furtherInfoText = ContentfulContentHelper.Paragraph("Test Further Info Text");
         var ratioText = ContentfulContentHelper.Paragraph("This is the ratio text");
+        var ratioTextForNotFullAndRelevant = ContentfulContentHelper.Paragraph("This is not F&R");
         var requirementsText = ContentfulContentHelper.Paragraph("This is the requirements text");
         return await Task.FromResult(new DetailsPage
                                      {
@@ -162,6 +163,7 @@ public class MockContentfulService : IContentService
                                                                           },
                                          RatiosHeading = "Test ratio heading",
                                          RatiosText = ratioText,
+                                         RatiosTextNotFullAndRelevant = ratioTextForNotFullAndRelevant,
                                          RequirementsHeading = "Test requirements heading",
                                          RequirementsText = requirementsText,
                                          CheckAnotherQualificationLink = new NavigationLink

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QualificationDetailsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QualificationDetailsController.cs
@@ -381,6 +381,7 @@ public class QualificationDetailsController(
                                  RequirementsText = await htmlRenderer.ToHtml(content.RequirementsText),
                                  RatiosHeading = content.RatiosHeading,
                                  RatiosText = await htmlRenderer.ToHtml(content.RatiosText),
+                                 RatiosTextNotFullAndRelevant = await htmlRenderer.ToHtml(content.RatiosTextNotFullAndRelevant),
                                  CheckAnotherQualificationLink =
                                      MapToNavigationLinkModel(content.CheckAnotherQualificationLink),
                                  PrintButtonText = content.PrintButtonText,

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/DetailsPageModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/DetailsPageModel.cs
@@ -25,6 +25,8 @@ public class DetailsPageModel
     public string RatiosHeading { get; init; } = string.Empty;
     
     public string RatiosText { get; init; } = string.Empty;
+
+    public string RatiosTextNotFullAndRelevant { get; init; } = string.Empty;
     
     public string RequirementsHeading { get; init; } = string.Empty;
     

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/RatioRequirementModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/RatioRequirementModel.cs
@@ -10,6 +10,8 @@ public class RatioRequirementModel
     
     public bool ApprovedForUnqualified { get; set; }
 
+    public bool IsNotFullAndRelevant => ApprovedForUnqualified && !ApprovedForLevel2 & !ApprovedForLevel3 && !ApprovedForLevel6;
+
     public string RequirementsHeadingForLevel2 { get; set; } = string.Empty;
     
     public string RequirementsForLevel2 { get; set; } = string.Empty;

--- a/src/Dfe.EarlyYearsQualification.Web/Views/QualificationDetails/Index.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/QualificationDetails/Index.cshtml
@@ -74,131 +74,140 @@
     </div>
     <div class="govuk-grid-column-full govuk-!-static-margin-top-6">
         <h2 class="govuk-heading-l" id="ratio-heading">@Model.Content.RatiosHeading</h2>
-        @Html.Raw(Model.Content.RatiosText)
         @{
-            if (Model.RatioRequirements.ApprovedForLevel2
-                || Model.RatioRequirements.ApprovedForLevel3
-                || Model.RatioRequirements.ApprovedForLevel6
-                || Model.RatioRequirements.ApprovedForUnqualified)
+            if (Model.RatioRequirements.IsNotFullAndRelevant)
             {
-                if (Model.RatioRequirements.ApprovedForLevel6)
-                {
-                    await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                       {
-                                                                           LevelText = "Level 6",
-                                                                           IsApproved = Model.RatioRequirements.ApprovedForLevel6,
-                                                                           AdditionalInformation = new AdditionalInformationModel
-                                                                                                   {
-                                                                                                       AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel6,
-                                                                                                       AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel6
-                                                                                                   }
-                                                                       });
-                }
-
-                if (Model.RatioRequirements.ApprovedForLevel3)
-                {
-                    await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                       {
-                                                                           LevelText = "Level 3",
-                                                                           IsApproved = Model.RatioRequirements.ApprovedForLevel3,
-                                                                           AdditionalInformation = new AdditionalInformationModel
-                                                                                                   {
-                                                                                                       AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel3,
-                                                                                                       AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel3
-                                                                                                   }
-                                                                       });
-                }
-
-                if (Model.RatioRequirements.ApprovedForLevel2)
-                {
-                    await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                       {
-                                                                           LevelText = "Level 2",
-                                                                           IsApproved = Model.RatioRequirements.ApprovedForLevel2,
-                                                                           AdditionalInformation = new AdditionalInformationModel
-                                                                                                   {
-                                                                                                       AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel2,
-                                                                                                       AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel2
-                                                                                                   }
-                                                                       });
-                }
-
-                if (Model.RatioRequirements.ApprovedForUnqualified)
-                {
-                    await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                       {
-                                                                           LevelText = "Unqualified",
-                                                                           IsApproved = Model.RatioRequirements.ApprovedForUnqualified,
-                                                                           AdditionalInformation = new AdditionalInformationModel
-                                                                                                   {
-                                                                                                       AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForUnqualified,
-                                                                                                       AdditionalInformationBody = Model.RatioRequirements.RequirementsForUnqualified
-                                                                                                   }
-                                                                       });
-                }
+                @Html.Raw(Model.Content.RatiosTextNotFullAndRelevant)
+            }
+            else
+            {
+                @Html.Raw(Model.Content.RatiosText)
+            }
+        }
+        @{
+        if (Model.RatioRequirements.ApprovedForLevel2
+            || Model.RatioRequirements.ApprovedForLevel3
+            || Model.RatioRequirements.ApprovedForLevel6
+            || Model.RatioRequirements.ApprovedForUnqualified)
+        {
+            if (Model.RatioRequirements.ApprovedForLevel6)
+            {
+                await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
+                                                                   {
+                                                                       LevelText = "Level 6",
+                                                                       IsApproved = Model.RatioRequirements.ApprovedForLevel6,
+                                                                       AdditionalInformation = new AdditionalInformationModel
+                                                                                               {
+                                                                                                   AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel6,
+                                                                                                   AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel6
+                                                                                               }
+                                                                   });
             }
 
-            if (!Model.RatioRequirements.ApprovedForLevel2
-                || !Model.RatioRequirements.ApprovedForLevel3
-                || !Model.RatioRequirements.ApprovedForLevel6
-                || !Model.RatioRequirements.ApprovedForUnqualified)
+            if (Model.RatioRequirements.ApprovedForLevel3)
             {
-                if (!Model.RatioRequirements.ApprovedForUnqualified)
-                {
-                    await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                       {
-                                                                           LevelText = "Unqualified",
-                                                                           IsApproved = Model.RatioRequirements.ApprovedForUnqualified,
-                                                                           AdditionalInformation = new AdditionalInformationModel
-                                                                                                   {
-                                                                                                       AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForUnqualified,
-                                                                                                       AdditionalInformationBody = Model.RatioRequirements.RequirementsForUnqualified
-                                                                                                   }
-                                                                       });
-                }
-
-                if (!Model.RatioRequirements.ApprovedForLevel2)
-                {
-                    await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                       {
-                                                                           LevelText = "Level 2",
-                                                                           IsApproved = Model.RatioRequirements.ApprovedForLevel2,
-                                                                           AdditionalInformation = new AdditionalInformationModel
-                                                                                                   {
-                                                                                                       AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel2,
-                                                                                                       AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel2
-                                                                                                   }
-                                                                       });
-                }
-                
-                if (!Model.RatioRequirements.ApprovedForLevel3)
-                {
-                    await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                       {
-                                                                           LevelText = "Level 3",
-                                                                           IsApproved = Model.RatioRequirements.ApprovedForLevel3,
-                                                                           AdditionalInformation = new AdditionalInformationModel
-                                                                                                   {
-                                                                                                       AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel3,
-                                                                                                       AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel3
-                                                                                                   }
-                                                                       });
-                }
-                
-                if (!Model.RatioRequirements.ApprovedForLevel6)
-                {
-                    await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                       {
-                                                                           LevelText = "Level 6",
-                                                                           IsApproved = Model.RatioRequirements.ApprovedForLevel6,
-                                                                           AdditionalInformation = new AdditionalInformationModel
-                                                                                                   {
-                                                                                                       AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel6,
-                                                                                                       AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel6
-                                                                                                   }
-                                                                       });
-                }
+                await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
+                                                                   {
+                                                                       LevelText = "Level 3",
+                                                                       IsApproved = Model.RatioRequirements.ApprovedForLevel3,
+                                                                       AdditionalInformation = new AdditionalInformationModel
+                                                                                               {
+                                                                                                   AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel3,
+                                                                                                   AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel3
+                                                                                               }
+                                                                   });
             }
+
+            if (Model.RatioRequirements.ApprovedForLevel2)
+            {
+                await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
+                                                                   {
+                                                                       LevelText = "Level 2",
+                                                                       IsApproved = Model.RatioRequirements.ApprovedForLevel2,
+                                                                       AdditionalInformation = new AdditionalInformationModel
+                                                                                               {
+                                                                                                   AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel2,
+                                                                                                   AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel2
+                                                                                               }
+                                                                   });
+            }
+
+            if (Model.RatioRequirements.ApprovedForUnqualified)
+            {
+                await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
+                                                                   {
+                                                                       LevelText = "Unqualified",
+                                                                       IsApproved = Model.RatioRequirements.ApprovedForUnqualified,
+                                                                       AdditionalInformation = new AdditionalInformationModel
+                                                                                               {
+                                                                                                   AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForUnqualified,
+                                                                                                   AdditionalInformationBody = Model.RatioRequirements.RequirementsForUnqualified
+                                                                                               }
+                                                                   });
+            }
+        }
+
+        if (!Model.RatioRequirements.ApprovedForLevel2
+            || !Model.RatioRequirements.ApprovedForLevel3
+            || !Model.RatioRequirements.ApprovedForLevel6
+            || !Model.RatioRequirements.ApprovedForUnqualified)
+        {
+            if (!Model.RatioRequirements.ApprovedForUnqualified)
+            {
+                await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
+                                                                   {
+                                                                       LevelText = "Unqualified",
+                                                                       IsApproved = Model.RatioRequirements.ApprovedForUnqualified,
+                                                                       AdditionalInformation = new AdditionalInformationModel
+                                                                                               {
+                                                                                                   AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForUnqualified,
+                                                                                                   AdditionalInformationBody = Model.RatioRequirements.RequirementsForUnqualified
+                                                                                               }
+                                                                   });
+            }
+
+            if (!Model.RatioRequirements.ApprovedForLevel2)
+            {
+                await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
+                                                                   {
+                                                                       LevelText = "Level 2",
+                                                                       IsApproved = Model.RatioRequirements.ApprovedForLevel2,
+                                                                       AdditionalInformation = new AdditionalInformationModel
+                                                                                               {
+                                                                                                   AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel2,
+                                                                                                   AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel2
+                                                                                               }
+                                                                   });
+            }
+                
+            if (!Model.RatioRequirements.ApprovedForLevel3)
+            {
+                await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
+                                                                   {
+                                                                       LevelText = "Level 3",
+                                                                       IsApproved = Model.RatioRequirements.ApprovedForLevel3,
+                                                                       AdditionalInformation = new AdditionalInformationModel
+                                                                                               {
+                                                                                                   AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel3,
+                                                                                                   AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel3
+                                                                                               }
+                                                                   });
+            }
+                
+            if (!Model.RatioRequirements.ApprovedForLevel6)
+            {
+                await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
+                                                                   {
+                                                                       LevelText = "Level 6",
+                                                                       IsApproved = Model.RatioRequirements.ApprovedForLevel6,
+                                                                       AdditionalInformation = new AdditionalInformationModel
+                                                                                               {
+                                                                                                   AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel6,
+                                                                                                   AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel6
+                                                                                               }
+                                                                   });
+            }
+        }
         }
 
         <h2 class="govuk-heading-l govuk-!-static-margin-top-9" id="requirements-heading">@Model.Content!.RequirementsHeading</h2>

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/pages/qualification-details-spec.cy.js
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/cypress/e2e/pages/qualification-details-spec.cy.js
@@ -61,6 +61,15 @@ describe("A spec used to test the qualification details page", () => {
     cy.get(".govuk-tag").eq(4).should("have.class", "govuk-tag--red");
   })
 
+  it("Checks the staff ratio text shows correctly when not full and relevant", () => {
+    // Value is '{"WhereWasQualificationAwarded":"england","WhenWasQualificationStarted":"7/2015","LevelOfQualification":"3","WhatIsTheAwardingOrganisation":"NCFE","SearchCriteria":"","AdditionalQuestionsAnswers":{"Test question":"yes","Test question 2":"yes"}}' encoded
+    cy.setCookie('user_journey', '%7B%22WhereWasQualificationAwarded%22%3A%22england%22%2C%22WhenWasQualificationStarted%22%3A%227%2F2015%22%2C%22LevelOfQualification%22%3A%223%22%2C%22WhatIsTheAwardingOrganisation%22%3A%22NCFE%22%2C%22SearchCriteria%22%3A%22%22%2C%22AdditionalQuestionsAnswers%22%3A%7B%22Test%20question%22%3A%22yes%22%2C%22Test%20question%202%22%3A%22yes%22%7D%7D');
+    cy.visit("/qualifications/qualification-details/eyq-240");
+
+    cy.get("#ratio-heading").should("contain.text", "Test ratio heading");
+    cy.get("#ratio-heading + p[class='govuk-body']").should("contain.text", "This is not F&R");
+  })
+
   it("Checks the order of the ratios on the page when a user answers an additional requirement question indicating not full and relevant", () => {
     // Value is '{"WhereWasQualificationAwarded":"england","WhenWasQualificationStarted":"7/2015","LevelOfQualification":"3","WhatIsTheAwardingOrganisation":"NCFE","SearchCriteria":"","AdditionalQuestionsAnswers":{"Test question":"yes","Test question 2":"yes"}}' encoded
     cy.setCookie('user_journey', '%7B%22WhereWasQualificationAwarded%22%3A%22england%22%2C%22WhenWasQualificationStarted%22%3A%227%2F2015%22%2C%22LevelOfQualification%22%3A%223%22%2C%22WhatIsTheAwardingOrganisation%22%3A%22NCFE%22%2C%22SearchCriteria%22%3A%22%22%2C%22AdditionalQuestionsAnswers%22%3A%7B%22Test%20question%22%3A%22yes%22%2C%22Test%20question%202%22%3A%22yes%22%7D%7D');

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
@@ -191,6 +191,10 @@ public class MockContentfulServiceTests
         result.QualificationDetailsSummaryHeader.Should().NotBeNullOrEmpty();
         result.QualificationNameLabel.Should().NotBeNullOrEmpty();
         result.QualificationStartDateLabel.Should().NotBeNullOrEmpty();
+        result.RatiosText!.Content[0].Should().BeAssignableTo<Paragraph>()
+              .Which.Content.Should().ContainSingle(x => ((Text)x).Value == "This is the ratio text");
+        result.RatiosTextNotFullAndRelevant!.Content[0].Should().BeAssignableTo<Paragraph>()
+              .Which.Content.Should().ContainSingle(x => ((Text)x).Value == "This is not F&R");
     }
 
     [TestMethod]


### PR DESCRIPTION
# Description

Updated to add in new ratio text when not F&R

## Ticket number (if applicable) - EYQB-536

# How Has This Been Tested?

Running locally, unit tests and e2e tests

# Screenshots

![image](https://github.com/user-attachments/assets/33e4e91a-b254-4303-9ffc-dc426739fefc)

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules