### PR TITLE
EYQB-656: Removed the margin bottom from the p tag in the feedback banner

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
+++ b/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
@@ -152,4 +152,5 @@ body {
 
 .feedback-banner-container .feedback-banner-body > p {
     font-size: 19px !important;
+    margin-bottom: 0;
 }


### PR DESCRIPTION
# Description

Removed the margin bottom from the p tag in the feedback banner

## Ticket number (if applicable) - EYQB-656

# How Has This Been Tested?

Running locally

# Screenshots

![image](https://github.com/user-attachments/assets/29438694-ad7f-4fcc-b99a-e3644e776f55)

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules