### PR TITLE
Define Azure Storage Account on deployed service only.

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Program.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Program.cs
@@ -29,11 +29,27 @@ if (!useMockContentful)
     var keyVaultEndpoint = builder.Configuration.GetSection("KeyVault").GetValue<string>("Endpoint");
     builder.Configuration.AddAzureKeyVault(new Uri(keyVaultEndpoint!), new DefaultAzureCredential());
 
-    var blobStorageConnectionString = builder.Configuration.GetSection("Storage").GetValue<string>("ConnectionString");
-    builder.Services.AddDataProtection()
-           .PersistKeysToAzureBlobStorage(blobStorageConnectionString, "data-protection", "data-protection")
+    builder.Services
+           .AddDataProtection()
            .ProtectKeysWithAzureKeyVault(new Uri($"{keyVaultEndpoint}keys/data-protection"),
                                          new DefaultAzureCredential());
+
+    if (!builder.Environment.IsDevelopment())
+    {
+        var blobStorageConnectionString =
+            builder.Configuration
+                   .GetSection("Storage")
+                   .GetValue<string>("ConnectionString");
+
+        const string containerName = "data-protection";
+        const string blobName = "data-protection";
+
+        builder.Services
+               .AddDataProtection()
+               .PersistKeysToAzureBlobStorage(blobStorageConnectionString,
+                                              containerName,
+                                              blobName);
+    }
 }
 
 // Add services to the container.


### PR DESCRIPTION
# Description

Allow developers to run locally by only picking up the Storage Account connection string on the service when deployed. When running locally, this allows the blob storage wrapper to avoid actually accessing the storage account.

## Ticket number (if applicable)

EYQB-534

# How Has This Been Tested?

Runs locally. 

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules