### PR TITLE
Define Azure Storage Account on deployed service only.

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Program.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Program.cs
@@ -160,5 +160,4 @@ await app.RunAsync();
 [ExcludeFromCodeCoverage]
 // ReSharper disable once UnusedType.Global
 // ...declared partial so we can exclude it from code coverage calculations
-public static partial class
-    Program;
+public static partial class Program;


### PR DESCRIPTION
# Description

Allow developers to run locally by only picking up the Storage Account connection string on the service when deployed. When running locally, this allows the blob storage wrapper to avoid actually accessing the storage account.

## Ticket number (if applicable)

EYQB-534

# How Has This Been Tested?

Runs locally. 

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules