### PR TITLE
Downgrade contentful libs to 8.0.1.

### DIFF
--- a/content/Dfe.EarlyYearsQualification.ContentUpload/Dfe.EarlyYearsQualification.ContentUpload.csproj
+++ b/content/Dfe.EarlyYearsQualification.ContentUpload/Dfe.EarlyYearsQualification.ContentUpload.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="contentful.csharp" Version="8.1.0" />
+      <PackageReference Include="contentful.csharp" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Dfe.EarlyYearsQualification.Content/Dfe.EarlyYearsQualification.Content.csproj
+++ b/src/Dfe.EarlyYearsQualification.Content/Dfe.EarlyYearsQualification.Content.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="contentful.csharp" Version="8.1.0" />
+    <PackageReference Include="contentful.csharp" Version="8.0.1" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>

--- a/src/Dfe.EarlyYearsQualification.Web/Dfe.EarlyYearsQualification.Web.csproj
+++ b/src/Dfe.EarlyYearsQualification.Web/Dfe.EarlyYearsQualification.Web.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.4" />
       <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.4" />
       <PackageReference Include="Azure.Identity" Version="1.12.0" />
-      <PackageReference Include="contentful.aspnetcore" Version="8.2.0" />
+      <PackageReference Include="contentful.aspnetcore" Version="8.0.1" />
       <PackageReference Include="GovUk.Frontend.AspNetCore" Version="2.2.0" />
       <PackageReference Include="jQuery" Version="3.7.1" />
       <PackageReference Include="moq" Version="4.20.72" />


### PR DESCRIPTION
# Description

Contentful content was not being rendered correctly for certain qualifications: for example, missing hyperlink in qualification EYQ-224. Tracked down to a Contentful change, issue was fixed by downgrading Contentful libraries to version 8.0.1.

## Ticket number (if applicable)

# How Has This Been Tested?

Ran locally, the missing content was rendered correctly. 

# Screenshots

![image](https://github.com/user-attachments/assets/08d24a13-0dfa-449a-a2af-abdaf464c5fa)

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules