### PR TITLE
Log in to az CLI again after scan

### DIFF
--- a/.github/workflows/dev-security-check.yml
+++ b/.github/workflows/dev-security-check.yml
@@ -2,8 +2,8 @@ name: ZAP Check - Dev
 
 on:
   schedule:
-    # Runs daily at 4am
-    - cron: "0 4 * * *"
+    # Runs daily at 4am, Monday through Friday
+    - cron: "0 4 * * 1-5"
 
 jobs:
 
@@ -42,6 +42,15 @@ jobs:
           target: https://${{ vars.WEBAPP_NAME }}.azurewebsites.net
           allow_issue_writing: false
           artifact_name: full_scan_dev
+      
+      # Login to Azure (again) using OIDC
+      # ...the ZAP scan takes long enough that it is likely the Azure CLI login has expired by now
+      - name: Login to Azure CLI
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       
       # Reset app setting following security scan
       - name: Reset the IsPublic flag


### PR DESCRIPTION
# Description

The OWASP ZAP scan step takes long enough that the Azure CLI login has expired. This means that the important step is failing that is supposed to reset the app to prevent casual public access.

Additionally, there is no point running this GitHub action on Saturday or Sunday morning, as the actions are not monitored and it would be exceptional for a failure to be picked up before Monday anyway.

## Ticket number (if applicable)

# How Has This Been Tested?

Hard to test without committing the code, as there is no on-demand trigger for the action. 

# Screenshots

![image](https://github.com/user-attachments/assets/502ad20c-7d96-426f-ad5c-257a1a8dde63)

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules