### PR TITLE
feature: added post content and hint header blocks to date question

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Content/Entities/DateQuestionPage.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/DateQuestionPage.cs
@@ -8,6 +8,7 @@ public class DateQuestionPage
 
     public string CtaButtonText { get; init; } = string.Empty;
     
+    public string QuestionHintHeader { get; init; } = string.Empty;
     public string QuestionHint { get; init; } = string.Empty;
 
     public string MonthLabel { get; init; } = string.Empty;
@@ -19,6 +20,7 @@ public class DateQuestionPage
     public string AdditionalInformationHeader { get; init; } = string.Empty;
 
     public Document? AdditionalInformationBody { get; init; }
+    public Document? PostHeaderContent { get; init; }
     
     public string ErrorBannerHeading { get; init; } = string.Empty;
 

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
@@ -563,6 +563,7 @@ public class MockContentfulService : IContentService
                    CtaButtonText = "Continue",
                    MonthLabel = "Test Month Label",
                    YearLabel = "Test Year Label",
+                   QuestionHintHeader = "Test Question Hint Header",
                    QuestionHint = "Test Question Hint",
                    BackButton = new NavigationLink
                                 {
@@ -572,6 +573,8 @@ public class MockContentfulService : IContentService
                                 },
                    AdditionalInformationBody =
                        ContentfulContentHelper.Paragraph("This is the additional information body"),
+                   PostHeaderContent = 
+                       ContentfulContentHelper.Paragraph("This is post header content"),
                    AdditionalInformationHeader = "This is the additional information header",
                    ErrorBannerHeading = "There is a problem",
                    ErrorBannerLinkText = "Test error banner link text",

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
@@ -277,8 +277,10 @@ public class QuestionsController(
 
         var additionalInformationBody = await contentParser.ToHtml(question.AdditionalInformationBody);
 
+        var postHeaderContent = await contentParser.ToHtml(question.PostHeaderContent);
+
         return DateQuestionMapper.Map(model, question, actionName, controllerName, errorBannerLinkText,
-                                      errorMessage, additionalInformationBody, validationResult, selectedMonth,
+                                      errorMessage, additionalInformationBody, postHeaderContent, validationResult, selectedMonth,
                                       selectedYear);
     }
 

--- a/src/Dfe.EarlyYearsQualification.Web/Mappers/DateQuestionMapper.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Mappers/DateQuestionMapper.cs
@@ -7,19 +7,21 @@ namespace Dfe.EarlyYearsQualification.Web.Mappers;
 public static class DateQuestionMapper
 {
     public static DateQuestionModel Map(DateQuestionModel model, DateQuestionPage question,
-                                                       string actionName,
-                                                       string controllerName,
-                                                       string errorBannerLinkText,
-                                                       string errorMessage,
-                                                       string additionalInformationBody,
-                                                       DateValidationResult? validationResult,
-                                                       int? selectedMonth,
-                                                       int? selectedYear)
+                                        string actionName,
+                                        string controllerName,
+                                        string errorBannerLinkText,
+                                        string errorMessage,
+                                        string additionalInformationBody,
+                                        string postHeaderContent,
+                                        DateValidationResult? validationResult,
+                                        int? selectedMonth,
+                                        int? selectedYear)
     {
         model.Question = question.Question;
         model.CtaButtonText = question.CtaButtonText;
         model.ActionName = actionName;
         model.ControllerName = controllerName;
+        model.QuestionHintHeader = question.QuestionHintHeader;
         model.QuestionHint = question.QuestionHint;
         model.MonthLabel = question.MonthLabel;
         model.YearLabel = question.YearLabel;
@@ -29,9 +31,10 @@ public static class DateQuestionMapper
         model.ErrorMessage = errorMessage;
         model.AdditionalInformationHeader = question.AdditionalInformationHeader;
         model.AdditionalInformationBody = additionalInformationBody;
+        model.PostHeaderContent = postHeaderContent;
         model.MonthError = !validationResult?.MonthValid ?? false;
         model.YearError = !validationResult?.YearValid ?? false;
-        
+
         // ReSharper disable once InvertIf
         if (selectedMonth.HasValue && selectedYear.HasValue)
         {

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/BaseQuestionModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/BaseQuestionModel.cs
@@ -13,12 +13,13 @@ public abstract class BaseQuestionModel
     public string ErrorMessage { get; set; } = string.Empty;
 
     public NavigationLinkModel? BackButton { get; set; }
-    
+
     public string ErrorBannerHeading { get; set; } = string.Empty;
 
     public string ErrorBannerLinkText { get; set; } = string.Empty;
-    
+
     public string AdditionalInformationHeader { get; set; } = string.Empty;
 
     public string AdditionalInformationBody { get; set; } = string.Empty;
+    public string PostHeaderContent { get; set; } = string.Empty;
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/DateQuestionModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/DateQuestionModel.cs
@@ -4,6 +4,7 @@ namespace Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
 
 public class DateQuestionModel : BaseQuestionModel
 {
+    public string QuestionHintHeader { get; set; } = string.Empty;
     public string QuestionHint { get; set; } = string.Empty;
 
     public string MonthLabel { get; set; } = string.Empty;

--- a/src/Dfe.EarlyYearsQualification.Web/Views/Questions/Date.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/Questions/Date.cshtml
@@ -40,6 +40,17 @@
                                                                                         });
                     }
 
+                    @if (!string.IsNullOrEmpty(Model.PostHeaderContent))
+                    {
+                        <div id="postHeaderContent">
+                            @Html.Raw(Model.PostHeaderContent)
+                        </div>
+                    }
+
+                    @if (!string.IsNullOrEmpty(Model.QuestionHintHeader))
+                    {
+                        <h2 class="govuk-heading-s" id="hintHeader">@Model.QuestionHintHeader</h2>
+                    }
                     <div id="date-format-hint" class="govuk-hint">@Model.QuestionHint</div>
 
                     @if (Model.MonthError || Model.YearError)

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/tests/pages/question.spec.ts
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/tests/pages/question.spec.ts
@@ -71,6 +71,8 @@ test.describe("A spec that tests question pages", () => {
 
         await checkText(page, ".govuk-details__summary-text", "This is the additional information header");
         await checkText(page, ".govuk-details__text", "This is the additional information body");
+        await checkText(page, "#postHeaderContent", "This is post header content");
+        await checkText(page, "#hintHeader", "Test Question Hint Header");
         await page.click(".govuk-details__summary-text");
         await hasAttribute(page, ".govuk-details", "open");
     });

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mappers/DateQuestionMapperTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mappers/DateQuestionMapperTests.cs
@@ -17,6 +17,7 @@ public class DateQuestionMapperTests
                            Question = "Question",
                            CtaButtonText = "Button Text",
                            QuestionHint = "Hint",
+                           QuestionHintHeader = "Question hint header",
                            MonthLabel = "Month label",
                            YearLabel = "Year label",
                            BackButton = new NavigationLink
@@ -33,12 +34,13 @@ public class DateQuestionMapperTests
         const string errorBannerLinkText = "error banner link text";
         const string errorMessage = "error message";
         const string additionalInformationBody = "additional information body";
+        const string postHeaderContent = "post-header content";
         var dateValidationResult = new DateValidationResult { MonthValid = false, YearValid = false };
         const int selectedMonth = 2;
         const int selectedYear = 2016;
 
         var result = DateQuestionMapper.Map(new DateQuestionModel(), question, actionName, controllerName,
-                                            errorBannerLinkText, errorMessage, additionalInformationBody,
+                                            errorBannerLinkText, errorMessage, additionalInformationBody, postHeaderContent,
                                             dateValidationResult, selectedMonth, selectedYear);
 
         result.Should().NotBeNull();
@@ -54,6 +56,9 @@ public class DateQuestionMapperTests
         result.ErrorMessage.Should().BeSameAs(errorMessage);
         result.AdditionalInformationHeader.Should().BeSameAs(question.AdditionalInformationHeader);
         result.AdditionalInformationBody.Should().BeSameAs(additionalInformationBody);
+        result.PostHeaderContent.Should().BeSameAs(postHeaderContent);
+        result.QuestionHint.Should().BeSameAs(question.QuestionHint);
+        result.QuestionHintHeader.Should().BeSameAs(question.QuestionHintHeader);
         result.MonthError.Should().BeTrue();
         result.YearError.Should().BeTrue();
         result.SelectedMonth.Should().NotBeNull();

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
@@ -2,7 +2,6 @@
 using Dfe.EarlyYearsQualification.Content.Constants;
 using Dfe.EarlyYearsQualification.Content.Entities;
 using Dfe.EarlyYearsQualification.Mock.Content;
-using FluentAssertions;
 
 namespace Dfe.EarlyYearsQualification.UnitTests.Mocks;
 
@@ -277,9 +276,12 @@ public class MockContentfulServiceTests
         result.AdditionalInformationHeader.Should().Be("This is the additional information header");
         result.AdditionalInformationBody!.Content[0].Should().BeAssignableTo<Paragraph>()
               .Which.Content.Should().ContainSingle(x => ((Text)x).Value == "This is the additional information body");
+        result.PostHeaderContent!.Content[0].Should().BeAssignableTo<Paragraph>()
+              .Which.Content.Should().ContainSingle(x => ((Text)x).Value == "This is post header content");
         result.MonthLabel.Should().Be("Test Month Label");
         result.YearLabel.Should().Be("Test Year Label");
         result.QuestionHint.Should().Be("Test Question Hint");
+        result.QuestionHintHeader.Should().Be("Test Question Hint Header");
         result.FutureDateErrorMessage.Should().Be("Future date error message");
         result.FutureDateErrorBannerLinkText.Should().Be("Future date error message banner link");
     }


### PR DESCRIPTION
# Description

Added new a new postheader block to the date page along with a hint header. These together allow for the changes required in the ticket to be handled via contentful and be customisable for other pages with limited adjustments

## EYQB-789
https://dfedigital.atlassian.net/browse/EYQB-789

# How Has This Been Tested?

manual testing, unit tests extended and passing and e2e tests extended and passing

# Screenshots

![image](https://github.com/user-attachments/assets/f5d4cba2-67fa-457b-ba0b-a3dfd553f015)
# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules