### PR TITLE
Challenge page redirects to start page if public

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/ChallengeController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/ChallengeController.cs
@@ -24,6 +24,11 @@ public class ChallengeController(
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public async Task<IActionResult> Index([FromQuery] ChallengePageModel model)
     {
+        if (accessKeysHelper.AllowPublicAccess)
+        {
+            return RedirectToAction("Index", "Home");
+        }
+
         if (!ModelState.IsValid)
         {
             logger.LogWarning("Invalid challenge model (get)");

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/ChallengeControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/ChallengeControllerTests.cs
@@ -499,4 +499,39 @@ public class ChallengeControllerTests
         modelToReturn.ErrorSummaryModel!.ErrorSummaryLinks.First().ErrorBannerLinkText.Should()
                      .Be(content!.IncorrectPasswordText);
     }
+
+    [TestMethod]
+    public async Task Get_WhenSetForPublicAccess_RedirectsToStartPage()
+    {
+        var mockLogger = new Mock<ILogger<ChallengeController>>();
+
+        var mockUrlHelper = new Mock<IUrlHelper>();
+        var contentService = new Mock<IContentService>();
+        var mockContentParser = new Mock<IGovUkContentParser>();
+        var accessKeysHelper = new Mock<ICheckServiceAccessKeysHelper>();
+
+        accessKeysHelper.SetupGet(x => x.AllowPublicAccess).Returns(true);
+
+        var controller = new ChallengeController(mockLogger.Object,
+                                                 mockUrlHelper.Object,
+                                                 contentService.Object,
+                                                 mockContentParser.Object,
+                                                 accessKeysHelper.Object);
+
+        controller.ControllerContext = new ControllerContext
+                                       {
+                                           HttpContext = new DefaultHttpContext()
+                                       };
+
+        var result = await controller.Index(new ChallengePageModel
+                                            { RedirectAddress = "/", PasswordValue = "Not A Correct Key" });
+
+        result.Should().BeAssignableTo<RedirectToActionResult>();
+
+        var redirect = result as RedirectToActionResult;
+
+        redirect.Should().NotBeNull();
+        redirect!.ActionName.Should().Be("Index");
+        redirect!.ControllerName.Should().Be("Home");
+    }
 }


### PR DESCRIPTION
# Description

In case people have bookmarked the challenge page, make it redirect to the start page if service instance is configured for public access.

## Ticket number (if applicable)

Ad hoc change. Ticket will be created.

# How Has This Been Tested?

New unit test. Checked locally, with public access configured on and off. 

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules