### PR TITLE
fix: split date banner errors so links can work independently

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/QuestionsController.cs
@@ -7,6 +7,7 @@ using Dfe.EarlyYearsQualification.Web.Constants;
 using Dfe.EarlyYearsQualification.Web.Controllers.Base;
 using Dfe.EarlyYearsQualification.Web.Helpers;
 using Dfe.EarlyYearsQualification.Web.Mappers;
+using Dfe.EarlyYearsQualification.Web.Models;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
 using Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
@@ -260,19 +261,28 @@ public class QuestionsController(
                                             int? selectedYear)
     {
         if (question is null) return null;
-        var bannerErrorText = validationResult is { BannerErrorMessages.Count: > 0 }
-                                  ? string.Join("<br />", validationResult.BannerErrorMessages)
-                                  : null;
+        var bannerErrors = validationResult is { BannerErrorMessages.Count: > 0 } ? validationResult.BannerErrorMessages : null;
 
         var errorMessageText = validationResult is { ErrorMessages.Count: > 0 }
                                    ? string.Join("<br />", validationResult.ErrorMessages)
                                    : null;
 
-        var errorBannerLinkText = placeholderUpdater.Replace(bannerErrorText ?? question.ErrorBannerLinkText);
+        var errorBannerMessages = new List<BannerError>();
+        if (bannerErrors is null)
+        {
+            errorBannerMessages.Add(new BannerError(question.ErrorMessage, FieldId.Month));
+        }
+        else
+        {
+            foreach (var bannerError in bannerErrors)
+            {
+                errorBannerMessages.Add(new BannerError(placeholderUpdater.Replace(bannerError.Message), bannerError.FieldId));
+            }
+        }
 
         var errorMessage = placeholderUpdater.Replace(errorMessageText ?? question.ErrorMessage);
 
-        return DateQuestionMapper.Map(model, question, errorBannerLinkText, errorMessage, validationResult,
+        return DateQuestionMapper.Map(model, question, errorBannerMessages, errorMessage, validationResult,
                                       selectedMonth, selectedYear);
     }
 

--- a/src/Dfe.EarlyYearsQualification.Web/Mappers/DateQuestionMapper.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Mappers/DateQuestionMapper.cs
@@ -8,7 +8,7 @@ namespace Dfe.EarlyYearsQualification.Web.Mappers;
 public static class DateQuestionMapper
 {
     public static DateQuestionModel Map(DateQuestionModel model, DateQuestion question,
-                                        string errorBannerLinkText,
+                                        List<BannerError> errorBannerMessages,
                                         string errorMessage,
                                         DateValidationResult? validationResult,
                                         int? selectedMonth,
@@ -22,10 +22,15 @@ public static class DateQuestionMapper
         model.MonthError = !validationResult?.MonthValid ?? false;
         model.YearError = !validationResult?.YearValid ?? false;
         model.ErrorMessage = errorMessage;
-        model.ErrorSummaryLink = new ErrorSummaryLink
-                                 {
-                                     ErrorBannerLinkText = errorBannerLinkText
-                                 };
+        model.ErrorSummaryLinks = [];
+        foreach (var errorBannerMessage in errorBannerMessages)
+        {
+            model.ErrorSummaryLinks.Add(new ErrorSummaryLink
+                                        {
+                                            ErrorBannerLinkText = errorBannerMessage.Message,
+                                            ElementLinkId = errorBannerMessage.FieldId.ToString()
+                                        });
+        }
 
         if (selectedMonth.HasValue && selectedYear.HasValue)
         {

--- a/src/Dfe.EarlyYearsQualification.Web/Mappers/DatesQuestionMapper.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Mappers/DatesQuestionMapper.cs
@@ -1,6 +1,7 @@
 using Dfe.EarlyYearsQualification.Content.Entities;
 using Dfe.EarlyYearsQualification.Web.Models;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
+using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
 
 namespace Dfe.EarlyYearsQualification.Web.Mappers;
 
@@ -24,7 +25,19 @@ public static class DatesQuestionMapper
             model.StartedQuestion.QuestionId = "date-started";
             model.StartedQuestion.MonthId = "StartedQuestion.SelectedMonth";
             model.StartedQuestion.YearId = "StartedQuestion.SelectedYear";
-            model.StartedQuestion.ErrorSummaryLink!.ElementLinkId = model.StartedQuestion.MonthError ? model.StartedQuestion.MonthId : model.StartedQuestion.YearId;
+
+            foreach (var errorSummaryLink in model.StartedQuestion.ErrorSummaryLinks)
+            {
+                if (errorSummaryLink.ElementLinkId == FieldId.Month.ToString())
+                {
+                    errorSummaryLink.ElementLinkId = model.StartedQuestion.MonthId;
+                }
+
+                else if (errorSummaryLink.ElementLinkId == FieldId.Year.ToString())
+                {
+                    errorSummaryLink.ElementLinkId = model.StartedQuestion.YearId;
+                }
+            }
         }
 
         if (awardedQuestion != null)
@@ -34,23 +47,34 @@ public static class DatesQuestionMapper
             model.AwardedQuestion.QuestionId = "date-awarded";
             model.AwardedQuestion.MonthId = "AwardedQuestion.SelectedMonth";
             model.AwardedQuestion.YearId = "AwardedQuestion.SelectedYear";
-            model.AwardedQuestion.ErrorSummaryLink!.ElementLinkId = model.AwardedQuestion.MonthError ? model.AwardedQuestion.MonthId : model.AwardedQuestion.YearId;
+            foreach (var errorSummaryLink in model.AwardedQuestion.ErrorSummaryLinks)
+            {
+                if (errorSummaryLink.ElementLinkId == FieldId.Month.ToString())
+                {
+                    errorSummaryLink.ElementLinkId = model.AwardedQuestion.MonthId;
+                }
+
+                else if (errorSummaryLink.ElementLinkId == FieldId.Year.ToString())
+                {
+                    errorSummaryLink.ElementLinkId = model.AwardedQuestion.YearId;
+                }
+            }
         }
 
         var errorLinks = new List<ErrorSummaryLink>();
 
         if (model.StartedQuestion is not null &&
             (model.StartedQuestion.MonthError || model.StartedQuestion.YearError) &&
-            model.StartedQuestion.ErrorSummaryLink is not null)
+            model.StartedQuestion.ErrorSummaryLinks is not null)
         {
-            errorLinks.Add(model.StartedQuestion.ErrorSummaryLink);
+            errorLinks.AddRange(model.StartedQuestion.ErrorSummaryLinks);
         }
 
         if (model.AwardedQuestion is not null &&
             (model.AwardedQuestion.MonthError || model.AwardedQuestion.YearError) &&
-            model.AwardedQuestion.ErrorSummaryLink is not null)
+            model.AwardedQuestion.ErrorSummaryLinks is not null)
         {
-            errorLinks.Add(model.AwardedQuestion.ErrorSummaryLink);
+            errorLinks.AddRange(model.AwardedQuestion.ErrorSummaryLinks);
         }
 
         model.Errors = new ErrorSummaryModel

--- a/src/Dfe.EarlyYearsQualification.Web/Models/BannerError.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/BannerError.cs
@@ -1,0 +1,7 @@
+﻿namespace Dfe.EarlyYearsQualification.Web.Models;
+
+public class BannerError(string message, FieldId fieldId)
+{
+    public string Message { get; set; } = message;
+    public FieldId FieldId { get; set; } = fieldId;
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/DateQuestionModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/DateQuestionModel.cs
@@ -28,5 +28,5 @@ public class DateQuestionModel
 
     public string Prefix { get; set; } = string.Empty;
 
-    public ErrorSummaryLink? ErrorSummaryLink { get; set; }
+    public List<ErrorSummaryLink> ErrorSummaryLinks { get; set; } = [];
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/DateQuestionModelValidator.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/DateQuestionModelValidator.cs
@@ -14,7 +14,7 @@ public class DateQuestionModelValidator(IDateTimeAdapter dateTimeAdapter) : IDat
             resultToReturn.MonthValid = false;
             resultToReturn.YearValid = false;
             resultToReturn.ErrorMessages.Add(question.ErrorMessage);
-            resultToReturn.BannerErrorMessages.Add(question.ErrorBannerLinkText);
+            resultToReturn.BannerErrorMessages.Add(new BannerError(question.ErrorBannerLinkText, FieldId.Month));
 
             return resultToReturn;
         }
@@ -23,21 +23,21 @@ public class DateQuestionModelValidator(IDateTimeAdapter dateTimeAdapter) : IDat
         {
             resultToReturn.MonthValid = false;
             resultToReturn.ErrorMessages.Add(question.MissingMonthErrorMessage);
-            resultToReturn.BannerErrorMessages.Add(question.MissingMonthBannerLinkText);
+            resultToReturn.BannerErrorMessages.Add(new BannerError(question.MissingMonthBannerLinkText, FieldId.Month));
         }
 
         if (model.SelectedMonth is <= 0 or > 12)
         {
             resultToReturn.MonthValid = false;
             resultToReturn.ErrorMessages.Add(question.MonthOutOfBoundsErrorMessage);
-            resultToReturn.BannerErrorMessages.Add(question.MonthOutOfBoundsErrorLinkText);
+            resultToReturn.BannerErrorMessages.Add(new BannerError(question.MonthOutOfBoundsErrorLinkText, FieldId.Month));
         }
 
         if (model.SelectedYear == null)
         {
             resultToReturn.YearValid = false;
             resultToReturn.ErrorMessages.Add(question.MissingYearErrorMessage);
-            resultToReturn.BannerErrorMessages.Add(question.MissingYearBannerLinkText);
+            resultToReturn.BannerErrorMessages.Add(new BannerError(question.MissingYearBannerLinkText, FieldId.Year));
         }
 
         var now = dateTimeAdapter.Now();
@@ -46,7 +46,7 @@ public class DateQuestionModelValidator(IDateTimeAdapter dateTimeAdapter) : IDat
         {
             resultToReturn.YearValid = false;
             resultToReturn.ErrorMessages.Add(question.YearOutOfBoundsErrorMessage);
-            resultToReturn.BannerErrorMessages.Add(question.YearOutOfBoundsErrorLinkText);
+            resultToReturn.BannerErrorMessages.Add(new BannerError(question.YearOutOfBoundsErrorLinkText, FieldId.Year));
         }
 
         if (resultToReturn.ErrorMessages.Count != 0)
@@ -61,7 +61,7 @@ public class DateQuestionModelValidator(IDateTimeAdapter dateTimeAdapter) : IDat
             resultToReturn.MonthValid = false;
             resultToReturn.YearValid = false;
             resultToReturn.ErrorMessages.Add(question.FutureDateErrorMessage);
-            resultToReturn.BannerErrorMessages.Add(question.FutureDateErrorBannerLinkText);
+            resultToReturn.BannerErrorMessages.Add(new BannerError(question.FutureDateErrorBannerLinkText, FieldId.Month));
         }
 
         return resultToReturn;
@@ -84,7 +84,7 @@ public class DateQuestionModelValidator(IDateTimeAdapter dateTimeAdapter) : IDat
                 awardedValidationResult.MonthValid = false;
                 awardedValidationResult.YearValid = false;
                 awardedValidationResult.ErrorMessages.Add(questionPage.AwardedDateIsAfterStartedDateErrorText);
-                awardedValidationResult.BannerErrorMessages.Add(questionPage.AwardedDateIsAfterStartedDateErrorText);
+                awardedValidationResult.BannerErrorMessages.Add(new BannerError(questionPage.AwardedDateIsAfterStartedDateErrorText, FieldId.Month));
             }
 
             return new DatesValidationResult

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/DateValidationResult.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QuestionModels/Validators/DateValidationResult.cs
@@ -6,7 +6,7 @@ public class DateValidationResult
 
     public bool YearValid { get; set; } = true;
 
-    public List<string> BannerErrorMessages { get; } = [];
+    public List<BannerError> BannerErrorMessages { get; set;  } = [];
 
     public List<string> ErrorMessages { get; init; } = [];
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Models/FieldId.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/FieldId.cs
@@ -1,0 +1,7 @@
+﻿namespace Dfe.EarlyYearsQualification.Web.Models;
+
+public enum FieldId
+{
+    Month,
+    Year
+}

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/tests/pages/question.spec.ts
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/tests/pages/question.spec.ts
@@ -265,7 +265,7 @@ test.describe("A spec that tests question pages", () => {
         await exists(page, '#awarded-error');
         await checkError(page, '#awarded-error', "Error- AwardedDateIsAfterStartedDateErrorText");
         await doesNotHaveClass(page, ".govuk-form-group", /govuk-form-group--error/, 0);
-        await hasClass(page, ".govuk-form-group", /govuk-form-group--error/,3);
+        await hasClass(page, ".govuk-form-group", /govuk-form-group--error/, 3);
         await doesNotHaveClass(page, "#StartedQuestion\\.SelectedMonth", /govuk-input--error/);
         await doesNotHaveClass(page, "#StartedQuestion\\.SelectedYear", /govuk-input--error/);
         await hasClass(page, "#AwardedQuestion\\.SelectedMonth", /govuk-input--error/);
@@ -285,8 +285,8 @@ test.describe("A spec that tests question pages", () => {
         await checkUrl(page, "/questions/when-was-the-qualification-started-and-awarded");
         await isVisible(page, ".govuk-error-summary");
         await checkText(page, ".govuk-error-summary__title", "There is a problem");
-        await checkText(page, "#error-banner-link", "started- Missing Month Banner Link Text",0);
-        await checkText(page, "#error-banner-link", "Error- AwardedDateIsAfterStartedDateErrorText",1);
+        await checkText(page, "#error-banner-link", "started- Missing Month Banner Link Text", 0);
+        await checkText(page, "#error-banner-link", "Error- AwardedDateIsAfterStartedDateErrorText", 1);
         await exists(page, "#started-error");
         await exists(page, '#awarded-error');
         await checkError(page, '#started-error', "started- Missing Month Error Message");
@@ -313,7 +313,8 @@ test.describe("A spec that tests question pages", () => {
         await checkUrl(page, "/questions/when-was-the-qualification-started-and-awarded");
         await isVisible(page, ".govuk-error-summary");
         await checkText(page, ".govuk-error-summary__title", "There is a problem");
-        await checkText(page, "#error-banner-link", "awarded- Missing Month Banner Link TextError- AwardedDateIsAfterStartedDateErrorText");
+        await checkText(page, "#error-banner-link", "awarded- Missing Month Banner Link Text", 0);
+        await checkText(page, "#error-banner-link", "Error- AwardedDateIsAfterStartedDateErrorText", 1);
         await doesNotExist(page, "#started-error");
         await exists(page, '#awarded-error');
         await checkError(page, '#awarded-error', "awarded- Missing Month Error MessageError- AwardedDateIsAfterStartedDateErrorText");
@@ -433,7 +434,8 @@ test.describe("A spec that tests question pages", () => {
         await checkUrl(page, "/questions/when-was-the-qualification-started-and-awarded");
         await isVisible(page, ".govuk-error-summary");
         await checkText(page, ".govuk-error-summary__title", "There is a problem");
-        await checkText(page, "#error-banner-link", "started- Month Out Of Bounds Error Link Textstarted- Year Out Of Bounds Error Link Text", 0);
+        await checkText(page, "#error-banner-link", "started- Month Out Of Bounds Error Link Text", 0);
+        await checkText(page, "#error-banner-link", "started- Year Out Of Bounds Error Link Text", 1);
         await exists(page, '#started-error');
         await checkError(page, '#started-error', "started- Month Out Of Bounds Error Messagestarted- Year Out Of Bounds Error Message");
         await hasClass(page, ".govuk-form-group", /govuk-form-group--error/, 0);
@@ -452,7 +454,8 @@ test.describe("A spec that tests question pages", () => {
         await checkUrl(page, "/questions/when-was-the-qualification-started-and-awarded");
         await isVisible(page, ".govuk-error-summary");
         await checkText(page, ".govuk-error-summary__title", "There is a problem");
-        await checkText(page, "#error-banner-link", "started- Month Out Of Bounds Error Link Textstarted- Missing Year Banner Link Text", 0);
+        await checkText(page, "#error-banner-link", "started- Month Out Of Bounds Error Link Text", 0);
+        await checkText(page, "#error-banner-link", "started- Missing Year Banner Link Text", 1);
         await exists(page, '#started-error');
         await checkError(page, '#started-error', "started- Month Out Of Bounds Error Messagestarted- Missing Year Error Message");
         await hasClass(page, ".govuk-form-group", /govuk-form-group--error/, 0);
@@ -471,7 +474,8 @@ test.describe("A spec that tests question pages", () => {
         await checkUrl(page, "/questions/when-was-the-qualification-started-and-awarded");
         await isVisible(page, ".govuk-error-summary");
         await checkText(page, ".govuk-error-summary__title", "There is a problem");
-        await checkText(page, "#error-banner-link", "started- Missing Month Banner Link Textstarted- Year Out Of Bounds Error Link Text", 0);
+        await checkText(page, "#error-banner-link", "started- Missing Month Banner Link Text", 0);
+        await checkText(page, "#error-banner-link", "started- Year Out Of Bounds Error Link Text", 1);
         await exists(page, '#started-error');
         await checkError(page, '#started-error', "started- Missing Month Error Messagestarted- Year Out Of Bounds Error Message");
         await hasClass(page, ".govuk-form-group", /govuk-form-group--error/, 0);
@@ -491,7 +495,8 @@ test.describe("A spec that tests question pages", () => {
         await checkUrl(page, "/questions/when-was-the-qualification-started-and-awarded");
         await isVisible(page, ".govuk-error-summary");
         await checkText(page, ".govuk-error-summary__title", "There is a problem");
-        await checkText(page, "#error-banner-link", "awarded- Month Out Of Bounds Error Link Textawarded- Year Out Of Bounds Error Link Text", 1);
+        await checkText(page, "#error-banner-link", "awarded- Month Out Of Bounds Error Link Text", 1);
+        await checkText(page, "#error-banner-link", "awarded- Year Out Of Bounds Error Link Text", 2);
         await exists(page, '#awarded-error');
         await checkError(page, '#awarded-error', "awarded- Month Out Of Bounds Error Messageawarded- Year Out Of Bounds Error Message");
         await hasClass(page, ".govuk-form-group", /govuk-form-group--error/, 0);
@@ -510,7 +515,8 @@ test.describe("A spec that tests question pages", () => {
         await checkUrl(page, "/questions/when-was-the-qualification-started-and-awarded");
         await isVisible(page, ".govuk-error-summary");
         await checkText(page, ".govuk-error-summary__title", "There is a problem");
-        await checkText(page, "#error-banner-link", "awarded- Month Out Of Bounds Error Link Textawarded- Missing Year Banner Link Text", 1);
+        await checkText(page, "#error-banner-link", "awarded- Month Out Of Bounds Error Link Text", 1);
+        await checkText(page, "#error-banner-link", "awarded- Missing Year Banner Link Text", 2);
         await exists(page, '#awarded-error');
         await checkError(page, '#awarded-error', "awarded- Month Out Of Bounds Error Messageawarded- Missing Year Error Message");
         await hasClass(page, ".govuk-form-group", /govuk-form-group--error/, 0);
@@ -529,7 +535,8 @@ test.describe("A spec that tests question pages", () => {
         await checkUrl(page, "/questions/when-was-the-qualification-started-and-awarded");
         await isVisible(page, ".govuk-error-summary");
         await checkText(page, ".govuk-error-summary__title", "There is a problem");
-        await checkText(page, "#error-banner-link", "awarded- Missing Month Banner Link Textawarded- Year Out Of Bounds Error Link Text", 1);
+        await checkText(page, "#error-banner-link", "awarded- Missing Month Banner Link Text", 1);
+        await checkText(page, "#error-banner-link", "awarded- Year Out Of Bounds Error Link Text", 2);
         await exists(page, '#awarded-error');
         await checkError(page, '#awarded-error', "awarded- Missing Month Error Messageawarded- Year Out Of Bounds Error Message");
         await hasClass(page, ".govuk-form-group", /govuk-form-group--error/, 0);

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -7,6 +7,7 @@ using Dfe.EarlyYearsQualification.Mock.Helpers;
 using Dfe.EarlyYearsQualification.Web.Constants;
 using Dfe.EarlyYearsQualification.Web.Controllers;
 using Dfe.EarlyYearsQualification.Web.Helpers;
+using Dfe.EarlyYearsQualification.Web.Models;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
 using Dfe.EarlyYearsQualification.Web.Services.UserJourneyCookieService;
@@ -433,6 +434,22 @@ public class QuestionsControllerTests
                                                      QuestionHint = "awarded- Test question hint"
                                                  }
                            };
+
+        var validationResult = new DatesValidationResult
+                               {
+                                   StartedValidationResult = new DateValidationResult
+                                                             {
+                                                                 MonthValid = false, YearValid = false,
+                                                                 ErrorMessages = ["Test error message"],
+                                                                 BannerErrorMessages = [new BannerError("Test banner error message", FieldId.Month), new BannerError("Test banner error message", FieldId.Year)]
+                                                             },
+                                   AwardedValidationResult = new DateValidationResult
+                                                             {
+                                                                 MonthValid = false, YearValid = false,
+                                                                 ErrorMessages = ["Test error message"],
+                                                                 BannerErrorMessages = [new BannerError("Test banner error message", FieldId.Month), new BannerError("Test banner error message", FieldId.Year)]
+                                                             }
+                               };
         mockContentService.Setup(x => x.GetDatesQuestionPage(QuestionPages.WhenWasTheQualificationStartedAndAwarded))
                           .ReturnsAsync(questionPage);
 
@@ -441,19 +458,7 @@ public class QuestionsControllerTests
                                                  mockQuestionModelValidator.Object, mockPlaceholderUpdater.Object);
 
         mockQuestionModelValidator.Setup(x => x.IsValid(It.IsAny<DatesQuestionModel>(), It.IsAny<DatesQuestionPage>()))
-                                  .Returns(new DatesValidationResult
-                                           {
-                                               StartedValidationResult = new DateValidationResult
-                                                                         {
-                                                                             MonthValid = false, YearValid = false,
-                                                                             ErrorMessages = ["Test error message"]
-                                                                         },
-                                               AwardedValidationResult = new DateValidationResult
-                                                                         {
-                                                                             MonthValid = false, YearValid = false,
-                                                                             ErrorMessages = ["Test error message"]
-                                                                         }
-                                           });
+                                  .Returns(validationResult);
 
         mockPlaceholderUpdater.Setup(x => x.Replace(It.IsAny<string>())).Returns<string>(x => x);
 
@@ -479,14 +484,16 @@ public class QuestionsControllerTests
         model.StartedQuestion.MonthLabel.Should().Be(questionPage.StartedQuestion.MonthLabel);
         model.StartedQuestion.YearLabel.Should().Be(questionPage.StartedQuestion.YearLabel);
         model.StartedQuestion.QuestionHint.Should().Be(questionPage.StartedQuestion.QuestionHint);
+        model.StartedQuestion.ErrorMessage.Should().Be(validationResult.StartedValidationResult.ErrorMessages[0]);
 
         model.AwardedQuestion!.Prefix.Should().Be("awarded");
         model.AwardedQuestion.QuestionId.Should().Be("date-awarded");
         model.AwardedQuestion.MonthId.Should().Be("AwardedQuestion.SelectedMonth");
-        model.AwardedQuestion.YearId.Should().Be("AwardedQuestion.SelectedYear");  
+        model.AwardedQuestion.YearId.Should().Be("AwardedQuestion.SelectedYear");
         model.AwardedQuestion.MonthLabel.Should().Be(questionPage.AwardedQuestion.MonthLabel);
         model.AwardedQuestion.YearLabel.Should().Be(questionPage.AwardedQuestion.YearLabel);
         model.AwardedQuestion.QuestionHint.Should().Be(questionPage.AwardedQuestion.QuestionHint);
+        model.AwardedQuestion.ErrorMessage.Should().Be(validationResult.AwardedValidationResult.ErrorMessages[0]);
 
         mockUserJourneyCookieService.Verify(x => x.SetWhenWasQualificationStarted(It.IsAny<string>()), Times.Never);
         mockUserJourneyCookieService.Verify(x => x.SetWhenWasQualificationAwarded(It.IsAny<string>()), Times.Never);
@@ -522,15 +529,15 @@ public class QuestionsControllerTests
         var result = await controller.WhenWasTheQualificationStarted(new DatesQuestionModel
                                                                      {
                                                                          StartedQuestion = new DateQuestionModel
-                                                                             {
-                                                                                 SelectedMonth = startedSelectedMonth,
-                                                                                 SelectedYear = startedSelectedYear
-                                                                             },
+                                                                                           {
+                                                                                               SelectedMonth = startedSelectedMonth,
+                                                                                               SelectedYear = startedSelectedYear
+                                                                                           },
                                                                          AwardedQuestion = new DateQuestionModel
-                                                                             {
-                                                                                 SelectedMonth = awardedSelectedMonth,
-                                                                                 SelectedYear = awardedSelectedYear
-                                                                             }
+                                                                                           {
+                                                                                               SelectedMonth = awardedSelectedMonth,
+                                                                                               SelectedYear = awardedSelectedYear
+                                                                                           }
                                                                      });
 
         result.Should().NotBeNull();

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mappers/DateQuestionMapperTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mappers/DateQuestionMapperTests.cs
@@ -1,5 +1,6 @@
 using Dfe.EarlyYearsQualification.Content.Entities;
 using Dfe.EarlyYearsQualification.Web.Mappers;
+using Dfe.EarlyYearsQualification.Web.Models;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels.Validators;
 
@@ -19,17 +20,20 @@ public class DateQuestionMapperTests
                            YearLabel = "Year label"
                        };
         const string errorBannerLinkText = "error banner link text";
+        const FieldId errorBannerLinkFieldId = FieldId.Year;
         const string errorMessage = "error message";
         var dateValidationResult = new DateValidationResult { MonthValid = false, YearValid = false };
         const int selectedMonth = 2;
         const int selectedYear = 2016;
 
-        var result = DateQuestionMapper.Map(new DateQuestionModel(), question, errorBannerLinkText, errorMessage,
+        var result = DateQuestionMapper.Map(new DateQuestionModel(), question, [new BannerError(errorBannerLinkText, errorBannerLinkFieldId)], errorMessage,
                                             dateValidationResult, selectedMonth, selectedYear);
 
         result.Should().NotBeNull();
         result.MonthLabel.Should().BeSameAs(question.MonthLabel);
         result.YearLabel.Should().BeSameAs(question.YearLabel);
+        result.ErrorSummaryLinks[0].ErrorBannerLinkText.Should().BeSameAs(errorBannerLinkText);
+        result.ErrorSummaryLinks[0].ElementLinkId.Should().BeSameAs(errorBannerLinkFieldId.ToString());
         result.ErrorMessage.Should().BeSameAs(errorMessage);
         result.QuestionHint.Should().BeSameAs(question.QuestionHint);
         result.QuestionHeader.Should().BeSameAs(question.QuestionHeader);

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/DateQuestionModelValidatorTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/DateQuestionModelValidatorTests.cs
@@ -199,8 +199,8 @@ public class DateQuestionModelValidatorTests
         result.YearValid.Should().BeFalse();
         result.ErrorMessages.Should().Contain(questionPage.MonthOutOfBoundsErrorMessage);
         result.ErrorMessages.Should().Contain(questionPage.YearOutOfBoundsErrorMessage);
-        result.BannerErrorMessages.Should().Contain(questionPage.MonthOutOfBoundsErrorLinkText);
-        result.BannerErrorMessages.Should().Contain(questionPage.YearOutOfBoundsErrorLinkText);
+        result.BannerErrorMessages.Select(o=>o.Message).Should().Contain(questionPage.MonthOutOfBoundsErrorLinkText);
+        result.BannerErrorMessages.Select(o=>o.Message).Should().Contain(questionPage.YearOutOfBoundsErrorLinkText);
     }
 
     [TestMethod]


### PR DESCRIPTION
# Description

Added ability for date errors to have independent links
Not particularly happy with the need to convert to string and back on the new enum but to change that will require a more significant rewrite of questionsController which I feel is out of scope for this ticket

## [EYQB-931](https://dfedigital.atlassian.net/browse/EYQB-931)

# How Has This Been Tested?

Manual testing and unit tests and e2e tests 
# Screenshots

![image](https://github.com/user-attachments/assets/4dcaec7b-2552-4de6-866f-fe052895f57f)
# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules