### PR TITLE
Added ability for user to set service to bypass the cache

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Caching/CachingHandler.cs
+++ b/src/Dfe.EarlyYearsQualification.Caching/CachingHandler.cs
@@ -7,6 +7,7 @@ namespace Dfe.EarlyYearsQualification.Caching;
 public class CachingHandler(
     IDistributedCache cache,
     IUrlToKeyConverter urlToKeyConverter,
+    ICachingOptionsManager cachingOptionsManager,
     ILogger<CachingHandler> logger)
     : DelegatingHandler(new HttpClientHandler())
 {
@@ -16,6 +17,13 @@ public class CachingHandler(
         if (request.RequestUri is null)
         {
             throw new ArgumentException(nameof(request.RequestUri));
+        }
+
+        var cachingOption = await cachingOptionsManager.GetCachingOption();
+
+        if (cachingOption == CachingOption.BypassCache)
+        {
+            return await InternalSendAsync(request, cancellationToken);
         }
 
         var cacheKey = await urlToKeyConverter.GetKeyAsync(request.RequestUri);

--- a/src/Dfe.EarlyYearsQualification.Caching/CachingOption.cs
+++ b/src/Dfe.EarlyYearsQualification.Caching/CachingOption.cs
@@ -1,0 +1,7 @@
+namespace Dfe.EarlyYearsQualification.Caching;
+
+public enum CachingOption
+{
+    None = 0,
+    BypassCache = 1
+}

--- a/src/Dfe.EarlyYearsQualification.Caching/Interfaces/ICachingOptionsManager.cs
+++ b/src/Dfe.EarlyYearsQualification.Caching/Interfaces/ICachingOptionsManager.cs
@@ -1,0 +1,8 @@
+namespace Dfe.EarlyYearsQualification.Caching.Interfaces;
+
+public interface ICachingOptionsManager
+{
+    public Task<CachingOption> GetCachingOption();
+
+    public Task SetCachingOption(CachingOption option);
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/OptionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/OptionsController.cs
@@ -9,7 +9,8 @@ namespace Dfe.EarlyYearsQualification.Web.Controllers;
 [Route("options")]
 public class OptionsController(
     ILogger<OptionsController> logger,
-    ICachingOptionsManager cachingOptionsManager)
+    ICachingOptionsManager cachingOptionsManager,
+    IConfiguration config)
     : ServiceController
 {
     [HttpGet]
@@ -17,11 +18,16 @@ public class OptionsController(
     {
         logger.LogInformation("Options page accessed.");
 
+        if (config["ENVIRONMENT"]?.StartsWith("prod", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return NotFound();
+        }
+
         var model = new OptionsPageModel();
 
         model.Option = model.Options.FirstOrDefault()!.Value;
 
-        await SetModelCachingOption(model);
+        await UseCachingOptionForModel(model);
 
         return View(model);
     }
@@ -31,6 +37,11 @@ public class OptionsController(
     {
         logger.LogInformation("Options page submitted.");
 
+        if (config["ENVIRONMENT"]?.StartsWith("prod", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return NotFound();
+        }
+
         if (ModelState.IsValid)
         {
             await SetCachingOption(model.Option);
@@ -39,7 +50,7 @@ public class OptionsController(
         return RedirectToAction("Index", "Home");
     }
 
-    private async Task SetModelCachingOption(OptionsPageModel model)
+    private async Task UseCachingOptionForModel(OptionsPageModel model)
     {
         var option = await cachingOptionsManager.GetCachingOption();
 

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/OptionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/OptionsController.cs
@@ -1,7 +1,7 @@
 using Dfe.EarlyYearsQualification.Caching;
 using Dfe.EarlyYearsQualification.Caching.Interfaces;
 using Dfe.EarlyYearsQualification.Web.Controllers.Base;
-using Dfe.EarlyYearsQualification.Web.Models.Content;
+using Dfe.EarlyYearsQualification.Web.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.EarlyYearsQualification.Web.Controllers;
@@ -36,7 +36,7 @@ public class OptionsController(
             await SetCachingOption(model.Option);
         }
 
-        return View(model);
+        return RedirectToAction("Index", "Home");
     }
 
     private async Task SetModelCachingOption(OptionsPageModel model)

--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/OptionsController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/OptionsController.cs
@@ -1,0 +1,61 @@
+using Dfe.EarlyYearsQualification.Caching;
+using Dfe.EarlyYearsQualification.Caching.Interfaces;
+using Dfe.EarlyYearsQualification.Web.Controllers.Base;
+using Dfe.EarlyYearsQualification.Web.Models.Content;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dfe.EarlyYearsQualification.Web.Controllers;
+
+[Route("options")]
+public class OptionsController(
+    ILogger<OptionsController> logger,
+    ICachingOptionsManager cachingOptionsManager)
+    : ServiceController
+{
+    [HttpGet]
+    public async Task<IActionResult> Index()
+    {
+        logger.LogInformation("Options page accessed.");
+
+        var model = new OptionsPageModel();
+
+        model.Option = model.Options.FirstOrDefault()!.Value;
+
+        await SetModelCachingOption(model);
+
+        return View(model);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Index(OptionsPageModel model)
+    {
+        logger.LogInformation("Options page submitted.");
+
+        if (ModelState.IsValid)
+        {
+            await SetCachingOption(model.Option);
+        }
+
+        return View(model);
+    }
+
+    private async Task SetModelCachingOption(OptionsPageModel model)
+    {
+        var option = await cachingOptionsManager.GetCachingOption();
+
+        if (option != CachingOption.None)
+        {
+            model.Option = option.ToString();
+        }
+    }
+
+    private async Task SetCachingOption(string option)
+    {
+        var optionOk = Enum.TryParse(option, out CachingOption cachingOption);
+
+        if (optionOk)
+        {
+            await cachingOptionsManager.SetCachingOption(cachingOption);
+        }
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/OptionsPageModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/OptionsPageModel.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
+
+namespace Dfe.EarlyYearsQualification.Web.Models.Content;
+
+public class OptionsPageModel
+{
+    private const string DefaultOptionValue = "Normal";
+    public string FormHeading { get; init; } = "Select an option";
+
+    public List<OptionModel> Options { get; init; } =
+        [
+            new()
+            {
+                Label = "Normal operation",
+                Hint = "Use the cache",
+                Value = DefaultOptionValue
+            },
+            new()
+            {
+                Label = "Bypass cache",
+                Hint = "The service will always ask for the latest content",
+                Value = "BypassCache"
+            }
+        ];
+
+    [Required]
+    public string Option { get; set; } = DefaultOptionValue;
+
+    public string? ButtonText { get; init; } = "Select option and continue";
+
+    public static string OptionAnswer
+    {
+        get { return "OptionAnswer"; }
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Models/OptionsPageModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/OptionsPageModel.cs
@@ -1,11 +1,11 @@
 using System.ComponentModel.DataAnnotations;
 using Dfe.EarlyYearsQualification.Web.Models.Content.QuestionModels;
 
-namespace Dfe.EarlyYearsQualification.Web.Models.Content;
+namespace Dfe.EarlyYearsQualification.Web.Models;
 
 public class OptionsPageModel
 {
-    private const string DefaultOptionValue = "Normal";
+    private const string DefaultOptionValue = "None";
     public string FormHeading { get; init; } = "Select an option";
 
     public List<OptionModel> Options { get; init; } =

--- a/src/Dfe.EarlyYearsQualification.Web/Services/Caching/CachingOptionsManager.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/Caching/CachingOptionsManager.cs
@@ -1,0 +1,54 @@
+using Dfe.EarlyYearsQualification.Caching;
+using Dfe.EarlyYearsQualification.Caching.Interfaces;
+using Dfe.EarlyYearsQualification.Web.Services.Cookies;
+
+namespace Dfe.EarlyYearsQualification.Web.Services.Caching;
+
+public class CachingOptionsManager(
+    ILogger<CachingOptionsManager> logger,
+    ICookieManager cookieManager) : ICachingOptionsManager
+{
+    private const string OptionsCookieKey = "option";
+
+    public Task<CachingOption> GetCachingOption()
+    {
+        logger.LogInformation("Getting user's caching option");
+
+        var cookies = cookieManager.ReadInboundCookies();
+
+        if (cookies == null
+            || !cookies.TryGetValue(OptionsCookieKey, out var optionVal)
+            || string.IsNullOrWhiteSpace(optionVal))
+        {
+            logger.LogInformation("User's caching option not set, using default value");
+            return Task.FromResult(CachingOption.None);
+        }
+
+        var ok = Enum.TryParse<CachingOption>(optionVal, out var optionEnum);
+
+        if (ok)
+        {
+            return Task.FromResult(optionEnum);
+        }
+
+        logger.LogWarning("User's caching option set to unexpected value {OptionVal}", optionVal);
+
+        return Task.FromResult(CachingOption.None);
+    }
+
+    public Task SetCachingOption(CachingOption option)
+    {
+        logger.LogInformation("Setting user's caching option to {Option}", option);
+
+        var cookieOptions = new CookieOptions
+                            {
+                                Expires = DateTimeOffset.UtcNow.AddDays(1),
+                                HttpOnly = true,
+                                Secure = true
+                            };
+
+        cookieManager.SetOutboundCookie(OptionsCookieKey, option.ToString(), cookieOptions);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Services/Caching/NeverBypassCacheManager.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/Caching/NeverBypassCacheManager.cs
@@ -1,0 +1,20 @@
+using Dfe.EarlyYearsQualification.Caching;
+using Dfe.EarlyYearsQualification.Caching.Interfaces;
+
+namespace Dfe.EarlyYearsQualification.Web.Services.Caching;
+
+/// <summary>
+///     An <see cref="ICachingOptionsManager" />, that always specifies caching behaviour.
+/// </summary>
+public class NeverBypassCacheManager : ICachingOptionsManager
+{
+    public Task<CachingOption> GetCachingOption()
+    {
+        return Task.FromResult(CachingOption.None);
+    }
+
+    public Task SetCachingOption(CachingOption option)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Services/Caching/SetupExtensions.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/Caching/SetupExtensions.cs
@@ -28,6 +28,9 @@ public static class SetupExtensions
                 SetupNoCache(builder);
                 break;
         }
+
+        builder.Services.AddScoped<ICachingOptionsManager, CachingOptionsManager>();
+        // ...when running in production, this code need to add a NeverBypassCacheManager singleton here instead
     }
 
     private static void SetupRedisCache(WebApplicationBuilder builder, IConfigurationSection? cacheConfiguration)

--- a/src/Dfe.EarlyYearsQualification.Web/ViewComponents/OptionsIndicatorViewComponent.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/ViewComponents/OptionsIndicatorViewComponent.cs
@@ -6,18 +6,21 @@ namespace Dfe.EarlyYearsQualification.Web.ViewComponents;
 
 public class OptionsIndicatorViewComponent(
     ILogger<OptionsIndicatorViewComponent> logger,
-    ICachingOptionsManager cachingOptionsManager) : ViewComponent
+    ICachingOptionsManager cachingOptionsManager,
+    IConfiguration config) : ViewComponent
 {
     public async Task<IViewComponentResult> InvokeAsync()
     {
         logger.LogInformation("Showing options view");
 
-        var option = await cachingOptionsManager.GetCachingOption();
+        var model = new OptionsPageModel();
 
-        var model = new OptionsPageModel
-                    {
-                        Option = option.ToString()
-                    };
+        if (config["ENVIRONMENT"]?.StartsWith("prod", StringComparison.OrdinalIgnoreCase) == false)
+        {
+            var option = await cachingOptionsManager.GetCachingOption();
+
+            model.Option = option.ToString();
+        }
 
         return View(model);
     }

--- a/src/Dfe.EarlyYearsQualification.Web/ViewComponents/OptionsIndicatorViewComponent.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/ViewComponents/OptionsIndicatorViewComponent.cs
@@ -1,0 +1,24 @@
+using Dfe.EarlyYearsQualification.Caching.Interfaces;
+using Dfe.EarlyYearsQualification.Web.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dfe.EarlyYearsQualification.Web.ViewComponents;
+
+public class OptionsIndicatorViewComponent(
+    ILogger<OptionsIndicatorViewComponent> logger,
+    ICachingOptionsManager cachingOptionsManager) : ViewComponent
+{
+    public async Task<IViewComponentResult> InvokeAsync()
+    {
+        logger.LogInformation("Showing options view");
+
+        var option = await cachingOptionsManager.GetCachingOption();
+
+        var model = new OptionsPageModel
+                    {
+                        Option = option.ToString()
+                    };
+
+        return View(model);
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Views/Options/Index.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/Options/Index.cshtml
@@ -1,5 +1,5 @@
 @using GovUk.Frontend.AspNetCore.TagHelpers
-@model Dfe.EarlyYearsQualification.Web.Models.Content.OptionsPageModel
+@model OptionsPageModel
 
 @{
     ViewData["Title"] = "Options";

--- a/src/Dfe.EarlyYearsQualification.Web/Views/Options/Index.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/Options/Index.cshtml
@@ -1,0 +1,44 @@
+@using GovUk.Frontend.AspNetCore.TagHelpers
+@model Dfe.EarlyYearsQualification.Web.Models.Content.OptionsPageModel
+
+@{
+    ViewData["Title"] = "Options";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
+        <form id="options-form" asp-controller="Options" method="post">
+            <div id="cookies-form-group" class="govuk-form-group">
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="cookies-choice-error">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h4 id="cookies-form-heading" class="govuk-heading-m">@Model.FormHeading</h4>
+                    </legend>
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        @foreach (var option in Model.Options)
+                        {
+                            var @checked = option.Value == Model.Option ? "checked" : "";
+                            <div class="govuk-radios__item">
+                                @Html.RadioButtonFor(x => x.Option, option.Value, new { @class = "govuk-radios__input", id = option.Value, @checked })
+                                <label class="govuk-label govuk-radios__label" for="@option.Value">
+                                    @option.Label
+                                </label>
+                                @if (!string.IsNullOrEmpty(option.Hint))
+                                {
+                                    var hintId = $"{option.Value}_hint";
+                                    <div id="@hintId" class="govuk-hint govuk-radios__hint">
+                                        @option.Hint
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+                    <div class="govuk-form-group">
+                        <button id="cookies-button" class="govuk-button" data-module="govuk-button">
+                            @Model.ButtonText
+                        </button>
+                    </div>
+                </fieldset>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/Dfe.EarlyYearsQualification.Web/Views/Shared/Components/OptionsIndicator/Default.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/Shared/Components/OptionsIndicator/Default.cshtml
@@ -4,8 +4,9 @@
 @{
     if (!Model.Option.Equals(CachingOption.None.ToString(), StringComparison.Ordinal))
     {
-        <div class="options-stamp">
+        <button class="options-stamp" onclick="window.location.href = '/options/';"
+                onKeyDown="window.location.href = '/options';" tabindex="0">
             Options: @Model.Option
-        </div>
+        </button>
     }
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Views/Shared/Components/OptionsIndicator/Default.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/Shared/Components/OptionsIndicator/Default.cshtml
@@ -1,0 +1,11 @@
+@using Dfe.EarlyYearsQualification.Caching
+@model OptionsPageModel
+
+@{
+    if (!Model.Option.Equals(CachingOption.None.ToString(), StringComparison.Ordinal))
+    {
+        <div class="options-stamp">
+            Options: @Model.Option
+        </div>
+    }
+}

--- a/src/Dfe.EarlyYearsQualification.Web/Views/Shared/Components/OptionsIndicator/Default.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/Shared/Components/OptionsIndicator/Default.cshtml
@@ -4,9 +4,8 @@
 @{
     if (!Model.Option.Equals(CachingOption.None.ToString(), StringComparison.Ordinal))
     {
-        <button class="options-stamp" onclick="window.location.href = '/options/';"
-                onKeyDown="window.location.href = '/options';" tabindex="0">
+        <a class="options-stamp" href="/" tabindex="0">
             Options: @Model.Option
-        </button>
+        </a>
     }
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/Shared/_Layout.cshtml
@@ -114,6 +114,8 @@
     }
 }
 @Html.GovUkFrontendScriptImports()
+
+@await Component.InvokeAsync("OptionsIndicator")
 </body>
 
 </html>

--- a/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
+++ b/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
@@ -476,7 +476,7 @@ body {
     margin-bottom: 30px;
 }
 
-.options-stamp {
+.options-stamp, .options-stamp:visited, .options-stamp:hover, .options-stamp:active {
     position: fixed;
     border: 3px solid maroon;
     color: maroon;

--- a/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
+++ b/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
@@ -472,6 +472,16 @@ body {
     padding: 0;
 }
 
-#qualification-details-summary{
+#qualification-details-summary {
     margin-bottom: 30px;
+}
+
+.options-stamp {
+    position: fixed;
+    border: 3px solid maroon;
+    color: maroon;
+    padding: 5px;
+    margin: 2px;
+    bottom: 0;
+    right: 0;
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/OptionsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/OptionsControllerTests.cs
@@ -1,0 +1,140 @@
+using Dfe.EarlyYearsQualification.Caching;
+using Dfe.EarlyYearsQualification.Caching.Interfaces;
+using Dfe.EarlyYearsQualification.Web.Controllers;
+using Dfe.EarlyYearsQualification.Web.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Dfe.EarlyYearsQualification.UnitTests.Controllers;
+
+[TestClass]
+public class OptionsControllerTests
+{
+    [TestMethod]
+    public async Task Get_InProduction_ReturnsNotFound()
+    {
+        var optionsManager = new Mock<ICachingOptionsManager>();
+        optionsManager.Setup(o => o.GetCachingOption()).ReturnsAsync(CachingOption.None);
+
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["ENVIRONMENT"]).Returns("production");
+
+        var controller = new OptionsController(NullLogger<OptionsController>.Instance,
+                                               optionsManager.Object,
+                                               config.Object);
+
+        var result = await controller.Index();
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [TestMethod]
+    public async Task Get_InLowerEnvironments_ReturnsView()
+    {
+        var optionsManager = new Mock<ICachingOptionsManager>();
+        optionsManager.Setup(o => o.GetCachingOption()).ReturnsAsync(CachingOption.None);
+
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["ENVIRONMENT"]).Returns("development");
+
+        var controller = new OptionsController(NullLogger<OptionsController>.Instance,
+                                               optionsManager.Object,
+                                               config.Object);
+
+        var result = await controller.Index();
+
+        result.Should().BeOfType<ViewResult>();
+
+        var viewResult = (ViewResult)result;
+
+        viewResult.Model.Should().BeOfType<OptionsPageModel>();
+
+        var model = viewResult.Model as OptionsPageModel;
+
+        model!.Option.Should().Be(CachingOption.None.ToString());
+    }
+
+    [TestMethod]
+    public async Task Get_InLowerEnvironments_ReturnsViewWithOptionSet()
+    {
+        var optionsManager = new Mock<ICachingOptionsManager>();
+        optionsManager.Setup(o => o.GetCachingOption()).ReturnsAsync(CachingOption.BypassCache);
+
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["ENVIRONMENT"]).Returns("development");
+
+        var controller = new OptionsController(NullLogger<OptionsController>.Instance,
+                                               optionsManager.Object,
+                                               config.Object);
+
+        var result = await controller.Index();
+
+        result.Should().BeOfType<ViewResult>();
+
+        var viewResult = (ViewResult)result;
+
+        viewResult.Model.Should().BeOfType<OptionsPageModel>();
+
+        var model = viewResult.Model as OptionsPageModel;
+
+        model!.Option.Should().Be(CachingOption.BypassCache.ToString());
+    }
+
+    [TestMethod]
+    public async Task Post_InProduction_ReturnsNotFound()
+    {
+        var optionsManager = new Mock<ICachingOptionsManager>();
+        optionsManager.Setup(o => o.GetCachingOption()).ReturnsAsync(CachingOption.None);
+
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["ENVIRONMENT"]).Returns("production");
+
+        var controller = new OptionsController(NullLogger<OptionsController>.Instance,
+                                               optionsManager.Object,
+                                               config.Object);
+
+        var result = await controller.Index(new OptionsPageModel());
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [TestMethod]
+    public async Task Post_InLowerEnvironments_ReturnsRedirectToStartPage()
+    {
+        var optionsManager = new Mock<ICachingOptionsManager>();
+        optionsManager.Setup(o => o.GetCachingOption()).ReturnsAsync(CachingOption.None);
+
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["ENVIRONMENT"]).Returns("development");
+
+        var controller = new OptionsController(NullLogger<OptionsController>.Instance,
+                                               optionsManager.Object,
+                                               config.Object);
+
+        var result = await controller.Index(new OptionsPageModel());
+
+        result.Should().BeOfType<RedirectToActionResult>();
+
+        var toActionResult = result as RedirectToActionResult;
+
+        toActionResult!.ActionName.Should().Be("Index");
+        toActionResult!.ControllerName.Should().Be("Home");
+    }
+
+    [TestMethod]
+    public async Task Post_InLowerEnvironments_SetsOption()
+    {
+        var optionsManager = new Mock<ICachingOptionsManager>();
+
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["ENVIRONMENT"]).Returns("development");
+
+        var controller = new OptionsController(NullLogger<OptionsController>.Instance,
+                                               optionsManager.Object,
+                                               config.Object);
+
+        await controller.Index(new OptionsPageModel { Option = CachingOption.BypassCache.ToString() });
+
+        optionsManager.Verify(x => x.SetCachingOption(CachingOption.BypassCache), Times.Once);
+    }
+}

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/CachingOptionsManagerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/CachingOptionsManagerTests.cs
@@ -1,0 +1,116 @@
+using Dfe.EarlyYearsQualification.Caching;
+using Dfe.EarlyYearsQualification.Web.Services.Caching;
+using Dfe.EarlyYearsQualification.Web.Services.Cookies;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Dfe.EarlyYearsQualification.UnitTests.Services;
+
+[TestClass]
+public class CachingOptionsManagerTests
+{
+    [TestMethod]
+    public async Task GetCachingOption_ReturnsExpectedValue()
+    {
+        var cookies = new Dictionary<string, string>
+                      {
+                          { "option", nameof(CachingOption.BypassCache) }
+                      };
+
+        var cookieManager = new Mock<ICookieManager>();
+        cookieManager.Setup(m => m.ReadInboundCookies())
+                     .Returns(cookies);
+
+        var sut = new CachingOptionsManager(NullLogger<CachingOptionsManager>.Instance, cookieManager.Object);
+
+        var option = await sut.GetCachingOption();
+
+        option.Should().Be(CachingOption.BypassCache);
+    }
+
+    [TestMethod]
+    public async Task WhenCookiesIsNull_GetCachingOption_ReturnsNone()
+    {
+        var cookieManager = new Mock<ICookieManager>();
+        cookieManager.Setup(m => m.ReadInboundCookies())
+                     .Returns((IDictionary<string, string>)null!);
+
+        var sut = new CachingOptionsManager(NullLogger<CachingOptionsManager>.Instance, cookieManager.Object);
+
+        var option = await sut.GetCachingOption();
+
+        option.Should().Be(CachingOption.None);
+    }
+
+    [TestMethod]
+    public async Task WhenCookiesHasNoOptionValue_GetCachingOption_ReturnsNone()
+    {
+        var cookies = new Dictionary<string, string>();
+
+        var cookieManager = new Mock<ICookieManager>();
+        cookieManager.Setup(m => m.ReadInboundCookies())
+                     .Returns(cookies);
+
+        var sut = new CachingOptionsManager(NullLogger<CachingOptionsManager>.Instance, cookieManager.Object);
+
+        var option = await sut.GetCachingOption();
+
+        option.Should().Be(CachingOption.None);
+    }
+
+    [TestMethod]
+    public async Task WhenCookiesHasEmptyOptionValue_GetCachingOption_ReturnsNone()
+    {
+        var cookies = new Dictionary<string, string>
+                      {
+                          { "option", "" }
+                      };
+
+        var cookieManager = new Mock<ICookieManager>();
+        cookieManager.Setup(m => m.ReadInboundCookies())
+                     .Returns(cookies);
+
+        var sut = new CachingOptionsManager(NullLogger<CachingOptionsManager>.Instance, cookieManager.Object);
+
+        var option = await sut.GetCachingOption();
+
+        option.Should().Be(CachingOption.None);
+    }
+
+    [TestMethod]
+    public async Task WhenCookiesHasUnexpectedOptionValue_GetCachingOption_ReturnsNone()
+    {
+        var cookies = new Dictionary<string, string>
+                      {
+                          { "option", "NotAValidValue" }
+                      };
+
+        var cookieManager = new Mock<ICookieManager>();
+        cookieManager.Setup(m => m.ReadInboundCookies())
+                     .Returns(cookies);
+
+        var sut = new CachingOptionsManager(NullLogger<CachingOptionsManager>.Instance, cookieManager.Object);
+
+        var option = await sut.GetCachingOption();
+
+        option.Should().Be(CachingOption.None);
+    }
+
+    [TestMethod]
+    public async Task WhenCookiesHasOptionValueNone_GetCachingOption_ReturnsNone()
+    {
+        var cookies = new Dictionary<string, string>
+                      {
+                          { "option", nameof(CachingOption.None) }
+                      };
+
+        var cookieManager = new Mock<ICookieManager>();
+        cookieManager.Setup(m => m.ReadInboundCookies())
+                     .Returns(cookies);
+
+        var sut = new CachingOptionsManager(NullLogger<CachingOptionsManager>.Instance, cookieManager.Object);
+
+        var option = await sut.GetCachingOption();
+
+        option.Should().Be(CachingOption.None);
+    }
+}

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/NeverBypassCacheManagerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/NeverBypassCacheManagerTests.cs
@@ -1,0 +1,40 @@
+using Dfe.EarlyYearsQualification.Caching;
+using Dfe.EarlyYearsQualification.Web.Services.Caching;
+
+namespace Dfe.EarlyYearsQualification.UnitTests.Services;
+
+[TestClass]
+public class NeverBypassCacheManagerTests
+{
+    [TestMethod]
+    public async Task Get_ReturnsNone()
+    {
+        var sut = new NeverBypassCacheManager();
+
+        var option = await sut.GetCachingOption();
+
+        option.Should().Be(CachingOption.None);
+    }
+
+    [TestMethod]
+    public async Task Set_DoesNotThrow()
+    {
+        var sut = new NeverBypassCacheManager();
+
+        var action = async () => await sut.SetCachingOption(CachingOption.BypassCache);
+
+        await action.Should().NotThrowAsync();
+    }
+
+    [TestMethod]
+    public async Task SetToBypassCache_ThenGet_ReturnsNone()
+    {
+        var sut = new NeverBypassCacheManager();
+
+        await sut.SetCachingOption(CachingOption.BypassCache);
+
+        var option = await sut.GetCachingOption();
+
+        option.Should().Be(CachingOption.None);
+    }
+}

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/ViewComponents/OptionsIndicatorViewComponentTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/ViewComponents/OptionsIndicatorViewComponentTests.cs
@@ -1,0 +1,91 @@
+using Dfe.EarlyYearsQualification.Caching;
+using Dfe.EarlyYearsQualification.Caching.Interfaces;
+using Dfe.EarlyYearsQualification.Web.Models;
+using Dfe.EarlyYearsQualification.Web.ViewComponents;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Dfe.EarlyYearsQualification.UnitTests.ViewComponents;
+
+[TestClass]
+public class OptionsIndicatorViewComponentTests
+{
+    [TestMethod]
+    public async Task InvokeAsync_InProduction_ReturnsView_WithDefaultOption()
+    {
+        var optionsManager = new Mock<ICachingOptionsManager>();
+        optionsManager.Setup(o => o.GetCachingOption()).ReturnsAsync(CachingOption.BypassCache);
+
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["ENVIRONMENT"]).Returns("production");
+
+        var sut = new OptionsIndicatorViewComponent(NullLogger<OptionsIndicatorViewComponent>.Instance,
+                                                    optionsManager.Object,
+                                                    config.Object);
+
+        var result = await sut.InvokeAsync();
+
+        result.Should().BeOfType<ViewViewComponentResult>();
+
+        var componentResult = result as ViewViewComponentResult;
+
+        componentResult!.ViewData!.Model.Should().BeOfType<OptionsPageModel>();
+
+        var model = componentResult.ViewData.Model as OptionsPageModel;
+
+        model!.Option.Should().Be(CachingOption.None.ToString());
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_IfEnvironmentNotSet_ReturnsView_WithDefaultOption()
+    {
+        var optionsManager = new Mock<ICachingOptionsManager>();
+        optionsManager.Setup(o => o.GetCachingOption()).ReturnsAsync(CachingOption.BypassCache);
+
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["ENVIRONMENT"]).Returns((string)null!);
+
+        var sut = new OptionsIndicatorViewComponent(NullLogger<OptionsIndicatorViewComponent>.Instance,
+                                                    optionsManager.Object,
+                                                    config.Object);
+
+        var result = await sut.InvokeAsync();
+
+        result.Should().BeOfType<ViewViewComponentResult>();
+
+        var componentResult = result as ViewViewComponentResult;
+
+        componentResult!.ViewData!.Model.Should().BeOfType<OptionsPageModel>();
+
+        var model = componentResult.ViewData.Model as OptionsPageModel;
+
+        model!.Option.Should().Be(CachingOption.None.ToString());
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_InLowerEnvironmentsReturnsView_WithCorrectOption()
+    {
+        var optionsManager = new Mock<ICachingOptionsManager>();
+        optionsManager.Setup(o => o.GetCachingOption()).ReturnsAsync(CachingOption.BypassCache);
+
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["ENVIRONMENT"]).Returns("development");
+
+        var sut = new OptionsIndicatorViewComponent(NullLogger<OptionsIndicatorViewComponent>.Instance,
+                                                    optionsManager.Object,
+                                                    config.Object);
+
+        var result = await sut.InvokeAsync();
+
+        result.Should().BeOfType<ViewViewComponentResult>();
+
+        var componentResult = result as ViewViewComponentResult;
+
+        componentResult!.ViewData!.Model.Should().BeOfType<OptionsPageModel>();
+
+        var model = componentResult.ViewData.Model as OptionsPageModel;
+
+        model!.Option.Should().Be(CachingOption.BypassCache.ToString());
+    }
+}


### PR DESCRIPTION
# Description

A new options page, on which is the ability for the user to bypass the Contentful cache. This will never be enabled in production.

To do:
* In production, disable the `/options` page. **DONE**
* In production, set up the `NeverBypassCache` service **DONE**
* Make the `/options` page "select and continue" button go to the start page after setting the option **DONE**
* Add indicator if option selected is any other than the default "production-like" behaviour option **DONE**

## Ticket number (if applicable)

EYQB-986

# How Has This Been Tested?

Tested locally, and in `dev`. 

# Screenshots

![image](https://github.com/user-attachments/assets/745aeff0-61c6-47ec-bb66-331dcb10d30a)

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules