### PR TITLE
Release/23-April-25-R1

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Controllers/CacheController.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Controllers/CacheController.cs
@@ -4,14 +4,16 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.EarlyYearsQualification.Web.Controllers;
 
+[IgnoreAntiforgeryToken]
+[Route("api/clear-distributed-cache")]
 public class CacheController(
     ILogger<CacheController> logger,
     ICacheInvalidator cacheInvalidator,
     IConfiguration configuration)
     : Controller // Do not inherit from Dfe.EarlyYearsQualification.Web.Controllers.Base.ServiceController
 {
-    [HttpGet("api/clear-distributed-cache")]
-    [HttpPost("api/clear-distributed-cache")]
+    [HttpGet]
+    [HttpPost]
     public async Task<IActionResult> Index()
     {
         logger.LogWarning("Call to endpoint to clear distributed cache");

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/CacheControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/CacheControllerTests.cs
@@ -321,4 +321,13 @@ public class CacheControllerTests
 
         result.Should().BeOfType<UnauthorizedResult>();
     }
+
+    [TestMethod]
+    public void CacheController_Has_IgnoreAntiForgeryAttribute()
+    {
+        object[] customAttributes = typeof(CacheController).GetCustomAttributes(false);
+
+        customAttributes.Should().Contain(x => x is IgnoreAntiforgeryTokenAttribute,
+                                          "Anti-forgery not used for API POST");
+    }
 }


### PR DESCRIPTION
# Description

Anti-forgery token not required for API `POST` requests.

# How Has This Been Tested?

Tested in `test`, successfully submitted `POST` request to endpoint with `curl`, verified it emptied the cache.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules