### PR TITLE
Delete redundant Key Vault certificate

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -59,8 +59,6 @@ This module provisions a new Azure Resource Group that assembles together the in
 | <a name="input_kv_certificate_authority_admin_phone_no"></a> [kv\_certificate\_authority\_admin\_phone\_no](#input\_kv\_certificate\_authority\_admin\_phone\_no) | Phone No. of the Certificate Authority Admin | `string` | n/a | yes |
 | <a name="input_kv_certificate_authority_password"></a> [kv\_certificate\_authority\_password](#input\_kv\_certificate\_authority\_password) | Password the Certificate provider | `string` | n/a | yes |
 | <a name="input_kv_certificate_authority_username"></a> [kv\_certificate\_authority\_username](#input\_kv\_certificate\_authority\_username) | Username for the Certificate provider | `string` | n/a | yes |
-| <a name="input_kv_certificate_label"></a> [kv\_certificate\_label](#input\_kv\_certificate\_label) | Label for the education.gov.uk certificate | `string` | n/a | yes |
-| <a name="input_kv_certificate_subject"></a> [kv\_certificate\_subject](#input\_kv\_certificate\_subject) | Subject of the education.gov.uk certificate | `string` | n/a | yes |
 | <a name="input_kv_service_gov_uk_certificate_label"></a> [kv\_service\_gov\_uk\_certificate\_label](#input\_kv\_service\_gov\_uk\_certificate\_label) | Label for the service.gov.uk certificate | `string` | n/a | yes |
 | <a name="input_kv_service_gov_uk_certificate_subject"></a> [kv\_service\_gov\_uk\_certificate\_subject](#input\_kv\_service\_gov\_uk\_certificate\_subject) | Subject of the service.gov.uk certificate | `string` | n/a | yes |
 | <a name="input_notifications_feedback_email_address"></a> [notifications\_feedback\_email\_address](#input\_notifications\_feedback\_email\_address) | GovUK Notify Feedback Email Address | `string` | n/a | yes |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -85,8 +85,6 @@ module "network" {
   kv_certificate_authority_admin_first_name = var.kv_certificate_authority_admin_first_name
   kv_certificate_authority_admin_last_name  = var.kv_certificate_authority_admin_last_name
   kv_certificate_authority_admin_phone_no   = var.kv_certificate_authority_admin_phone_no
-  kv_certificate_label                      = var.kv_certificate_label
-  kv_certificate_subject                    = var.kv_certificate_subject
   kv_service_gov_uk_certificate_label       = var.kv_service_gov_uk_certificate_label
   kv_service_gov_uk_certificate_subject     = var.kv_service_gov_uk_certificate_subject
   contentful_delivery_api_key               = var.contentful_delivery_api_key

--- a/terraform/modules/azure-network/README.md
+++ b/terraform/modules/azure-network/README.md
@@ -24,7 +24,6 @@ No modules.
 | [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
 | [azurerm_key_vault_access_policy.kv_gh_ap](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.kv_mi_ap](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_certificate.kv_cert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_certificate) | resource |
 | [azurerm_key_vault_certificate.kv_service_gov_uk_cert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_certificate) | resource |
 | [azurerm_key_vault_certificate_issuer.kv_ca](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_certificate_issuer) | resource |
 | [azurerm_key_vault_key.data-protection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key) | resource |
@@ -57,8 +56,6 @@ No modules.
 | <a name="input_kv_certificate_authority_name"></a> [kv\_certificate\_authority\_name](#input\_kv\_certificate\_authority\_name) | Name of the Certificate Authority | `string` | n/a | yes |
 | <a name="input_kv_certificate_authority_password"></a> [kv\_certificate\_authority\_password](#input\_kv\_certificate\_authority\_password) | Password the Certificate provider | `string` | n/a | yes |
 | <a name="input_kv_certificate_authority_username"></a> [kv\_certificate\_authority\_username](#input\_kv\_certificate\_authority\_username) | Username for the Certificate provider | `string` | n/a | yes |
-| <a name="input_kv_certificate_label"></a> [kv\_certificate\_label](#input\_kv\_certificate\_label) | Label for the education.gov.uk certificate | `string` | n/a | yes |
-| <a name="input_kv_certificate_subject"></a> [kv\_certificate\_subject](#input\_kv\_certificate\_subject) | Subject of the education.gov.uk certificate | `string` | n/a | yes |
 | <a name="input_kv_service_gov_uk_certificate_label"></a> [kv\_service\_gov\_uk\_certificate\_label](#input\_kv\_service\_gov\_uk\_certificate\_label) | Label for the service.gov.uk certificate | `string` | n/a | yes |
 | <a name="input_kv_service_gov_uk_certificate_subject"></a> [kv\_service\_gov\_uk\_certificate\_subject](#input\_kv\_service\_gov\_uk\_certificate\_subject) | Subject of the service.gov.uk certificate | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Name of the Azure region to deploy resources | `string` | n/a | yes |
@@ -72,7 +69,6 @@ No modules.
 | <a name="output_agw_pip_id"></a> [agw\_pip\_id](#output\_agw\_pip\_id) | ID of the Public IP address for the App Gateway |
 | <a name="output_agw_subnet_id"></a> [agw\_subnet\_id](#output\_agw\_subnet\_id) | ID of the Subnet for the App Gateway |
 | <a name="output_cache_subnet_id"></a> [cache\_subnet\_id](#output\_cache\_subnet\_id) | ID of the Subnet for the Redis cache |
-| <a name="output_kv_cert_secret_id"></a> [kv\_cert\_secret\_id](#output\_kv\_cert\_secret\_id) | education.gov.uk SSL certificate Secret ID |
 | <a name="output_kv_id"></a> [kv\_id](#output\_kv\_id) | ID of the Key Vault |
 | <a name="output_kv_mi_id"></a> [kv\_mi\_id](#output\_kv\_mi\_id) | ID of the Managed Identity for the Key Vault |
 | <a name="output_kv_service_gov_uk_cert_secret_id"></a> [kv\_service\_gov\_uk\_cert\_secret\_id](#output\_kv\_service\_gov\_uk\_cert\_secret\_id) | service.gov.uk SSL certificate Secret ID |

--- a/terraform/modules/azure-network/key-vault.tf
+++ b/terraform/modules/azure-network/key-vault.tf
@@ -107,48 +107,6 @@ resource "azurerm_key_vault_certificate_issuer" "kv_ca" {
   }
 }
 
-resource "azurerm_key_vault_certificate" "kv_cert" {
-  # Certificate only deployed to the Test and Production subscription
-  count = var.environment != "development" ? 1 : 0
-
-  name         = var.kv_certificate_label
-  key_vault_id = azurerm_key_vault.kv.id
-
-  certificate_policy {
-    issuer_parameters {
-      name = var.kv_certificate_authority_label
-    }
-
-    key_properties {
-      exportable = true
-      key_size   = 2048
-      key_type   = "RSA"
-      reuse_key  = true
-    }
-
-    lifetime_action {
-      action {
-        action_type = "AutoRenew"
-      }
-
-      trigger {
-        days_before_expiry = 30
-      }
-    }
-
-    secret_properties {
-      content_type = "application/x-pkcs12"
-    }
-
-    x509_certificate_properties {
-      extended_key_usage = ["1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.2"]
-      key_usage          = ["digitalSignature", "keyEncipherment"]
-      subject            = var.kv_certificate_subject
-      validity_in_months = 12
-    }
-  }
-}
-
 resource "azurerm_key_vault_certificate" "kv_service_gov_uk_cert" {
   # Certificate only deployed to the Test and Production subscription
   count = var.environment != "development" ? 1 : 0

--- a/terraform/modules/azure-network/key-vault.tf
+++ b/terraform/modules/azure-network/key-vault.tf
@@ -56,6 +56,7 @@ resource "azurerm_key_vault_access_policy" "kv_gh_ap" {
 
   certificate_permissions = [
     "Create",
+    "Delete",
     "Get",
     "GetIssuers",
     "Import",

--- a/terraform/modules/azure-network/outputs.tf
+++ b/terraform/modules/azure-network/outputs.tf
@@ -33,11 +33,6 @@ output "kv_id" {
   value       = azurerm_key_vault.kv.id
 }
 
-output "kv_cert_secret_id" {
-  description = "education.gov.uk SSL certificate Secret ID"
-  value       = var.environment != "development" ? azurerm_key_vault_certificate.kv_cert[0].secret_id : null
-}
-
 output "kv_service_gov_uk_cert_secret_id" {
   description = "service.gov.uk SSL certificate Secret ID"
   value       = var.environment != "development" ? azurerm_key_vault_certificate.kv_service_gov_uk_cert[0].secret_id : null

--- a/terraform/modules/azure-network/variables.tf
+++ b/terraform/modules/azure-network/variables.tf
@@ -58,16 +58,6 @@ variable "kv_certificate_authority_admin_phone_no" {
   type        = string
 }
 
-variable "kv_certificate_label" {
-  description = "Label for the education.gov.uk certificate"
-  type        = string
-}
-
-variable "kv_certificate_subject" {
-  description = "Subject of the education.gov.uk certificate"
-  type        = string
-}
-
 variable "kv_service_gov_uk_certificate_label" {
   description = "Label for the service.gov.uk certificate"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,16 +51,6 @@ variable "kv_certificate_authority_admin_phone_no" {
   sensitive   = true
 }
 
-variable "kv_certificate_label" {
-  description = "Label for the education.gov.uk certificate"
-  type        = string
-}
-
-variable "kv_certificate_subject" {
-  description = "Subject of the education.gov.uk certificate"
-  type        = string
-}
-
 variable "kv_service_gov_uk_certificate_label" {
   description = "Label for the service.gov.uk certificate"
   type        = string


### PR DESCRIPTION
# Description

The education.gov.uk domain is no longer in use by the service, so we are removing the associated infrastructure.

The custom domain was deleted in phase 1 (#605).

This is phase 2: deletion of the certificate.

## Ticket number (if applicable)

EYQB-1022

# How Has This Been Tested?

Tested in `dev` and `staging` environments before going to production.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules