### PR TITLE
EYQB-1055: Minor logic change to the use the automatically approved at L6 flag

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Services/QualificationDetails/QualificationDetailsService.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/QualificationDetails/QualificationDetailsService.cs
@@ -170,6 +170,11 @@ public class QualificationDetailsService(
                               List<AdditionalRequirementAnswerModel>?
                                   additionalRequirementAnswerModels)
     {
+        if (qualification.IsAutomaticallyApprovedAtLevel6)
+        {
+            return true;
+        }
+        
         if (additionalRequirementAnswerModels is null || qualification.AdditionalRequirementQuestions is null)
         {
             return false;


### PR DESCRIPTION
# Description

Minor logic change to the use the automatically approved at L6 flag

## Ticket number (if applicable) - EYQB-1055

# How Has This Been Tested?

Unit test, running locally

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules