### PR TITLE
EYQB-1236 moved logic that renders the ratio rows to the view model

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QualificationDetailsModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QualificationDetailsModel.cs
@@ -15,6 +15,108 @@ public class QualificationDetailsModel : BasicQualificationModel
     public RatioRequirementModel RatioRequirements { get; set; } = new();
 
     public UpDownFeedbackModel? UpDownFeedback { get; init; }
+
     public string DateStarted { get; init; } = string.Empty;
+
     public string DateAwarded { get; init; } = string.Empty;
+
+    public List<RatioRowModel> OrderRatioRows()
+    {
+        var ratioRowModels = new List<RatioRowModel>
+                             {
+                                 new RatioRowModel
+                                 {
+                                     Level = 6,
+                                     LevelText = "Level 6",
+                                     ApprovalStatus = RatioRequirements.ApprovedForLevel6,
+                                     AdditionalInformation = new AdditionalInformationModel
+                                                             {
+                                                                 AdditionalInformationHeader =
+                                                                     RatioRequirements.RequirementsHeadingForLevel6,
+                                                                 AdditionalInformationBody =
+                                                                     RatioRequirements.RequirementsForLevel6,
+                                                                 ShowAdditionalInformationBodyByDefault =
+                                                                     RatioRequirements.ApprovedForLevel6
+                                                                         is QualificationApprovalStatus.NotApproved
+                                                                            or QualificationApprovalStatus
+                                                                                .PossibleRouteAvailable
+                                                                     && RatioRequirements
+                                                                         .ShowRequirementsForLevel6ByDefault
+                                                             }
+                                 },
+                                 new RatioRowModel
+                                 {
+                                     Level = 3,
+                                     LevelText = "Level 3",
+                                     ApprovalStatus = RatioRequirements.ApprovedForLevel3,
+                                     AdditionalInformation = new AdditionalInformationModel
+                                                             {
+                                                                 AdditionalInformationHeader =
+                                                                     RatioRequirements.RequirementsHeadingForLevel3,
+                                                                 AdditionalInformationBody =
+                                                                     RatioRequirements.RequirementsForLevel3,
+                                                                 ShowAdditionalInformationBodyByDefault =
+                                                                     RatioRequirements.ApprovedForLevel3
+                                                                         is QualificationApprovalStatus.NotApproved
+                                                                            or QualificationApprovalStatus
+                                                                                .PossibleRouteAvailable
+                                                                     && RatioRequirements
+                                                                         .ShowRequirementsForLevel3ByDefault
+                                                             }
+                                 },
+                                 new RatioRowModel
+                                 {
+                                     Level = 2,
+                                     LevelText = "Level 2",
+                                     ApprovalStatus = RatioRequirements.ApprovedForLevel2,
+                                     AdditionalInformation = new AdditionalInformationModel
+                                                             {
+                                                                 AdditionalInformationHeader =
+                                                                     RatioRequirements.RequirementsHeadingForLevel2,
+                                                                 AdditionalInformationBody =
+                                                                     RatioRequirements.RequirementsForLevel2,
+                                                                 ShowAdditionalInformationBodyByDefault =
+                                                                     RatioRequirements
+                                                                         .ShowRequirementsForLevel2ByDefault
+                                                             }
+                                 },
+                                 new RatioRowModel
+                                 {
+                                     Level = 0,
+                                     LevelText = "Unqualified",
+                                     ApprovalStatus = RatioRequirements.ApprovedForUnqualified,
+                                     AdditionalInformation = new AdditionalInformationModel
+                                                             {
+                                                                 AdditionalInformationHeader =
+                                                                     RatioRequirements
+                                                                         .RequirementsHeadingForUnqualified,
+                                                                 AdditionalInformationBody =
+                                                                     RatioRequirements.RequirementsForUnqualified
+                                                             }
+                                 }
+                             };
+
+        var approvedRows = ratioRowModels.Where(x => x.ApprovalStatus == QualificationApprovalStatus.Approved)
+                                         .OrderByDescending(x => x.Level);
+
+        var nonApprovedRows = ratioRowModels.Where(x => x.ApprovalStatus != QualificationApprovalStatus.Approved)
+                                            .OrderBy(x => x.Level);
+
+        return approvedRows.Concat(nonApprovedRows).ToList();
+    }
+
+    public QualificationResultModel QualificationResultModel => new()
+                                                                {
+                                                                    Heading = Content!
+                                                                        .QualificationResultHeading,
+                                                                    MessageHeading =
+                                                                        Content
+                                                                            .QualificationResultMessageHeading,
+                                                                    MessageBody =
+                                                                        Content
+                                                                            .QualificationResultMessageBody,
+                                                                    IsFullAndRelevant =
+                                                                        RatioRequirements
+                                                                            .IsNotFullAndRelevant
+                                                                };
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Models/RatioRowModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/RatioRowModel.cs
@@ -2,6 +2,8 @@ namespace Dfe.EarlyYearsQualification.Web.Models;
 
 public class RatioRowModel
 {
+    public int Level { get; init; }
+    
     public string LevelText { get; init; } = string.Empty;
 
     public string RatioId

--- a/src/Dfe.EarlyYearsQualification.Web/Views/QualificationDetails/Index.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/QualificationDetails/Index.cshtml
@@ -1,5 +1,4 @@
 ﻿@using System.Globalization
-@using Dfe.EarlyYearsQualification.Web.Models.Content
 @model Dfe.EarlyYearsQualification.Web.Models.Content.QualificationDetailsModel
 
 @{
@@ -99,13 +98,7 @@
     </div>
     <div class="govuk-grid-column-full govuk-!-static-margin-top-6 dont-float">
         <div id="qualification-result" class="govuk-grid-column-two-thirds-from-desktop dont-float">
-            @{ await Html.RenderPartialAsync("Partials/QualificationResult", new QualificationResultModel
-                                                                             {
-                                                                                 Heading = Model.Content.QualificationResultHeading,
-                                                                                 MessageHeading = Model.Content.QualificationResultMessageHeading,
-                                                                                 MessageBody = Model.Content.QualificationResultMessageBody,
-                                                                                 IsFullAndRelevant = !Model.RatioRequirements.IsNotFullAndRelevant
-                                                                             }); }
+            @{ await Html.RenderPartialAsync("Partials/QualificationResult", Model.QualificationResultModel); }
 
             <h2 class="govuk-heading-l" id="ratio-heading">@Model.Content.RatiosHeading</h2>
             @if (!string.IsNullOrEmpty(Model.Content.RatiosText))
@@ -120,139 +113,11 @@
                 </div>
             }
 
-            @{
-                if (Model.RatioRequirements.ApprovedForLevel2 == QualificationApprovalStatus.Approved
-                    || Model.RatioRequirements.ApprovedForLevel3 == QualificationApprovalStatus.Approved
-                    || Model.RatioRequirements.ApprovedForLevel6 == QualificationApprovalStatus.Approved
-                    || Model.RatioRequirements.ApprovedForUnqualified == QualificationApprovalStatus.Approved)
-                {
-                    if (Model.RatioRequirements.ApprovedForLevel6 == QualificationApprovalStatus.Approved)
-                    {
-                        await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                           {
-                                                                               LevelText = "Level 6",
-                                                                               ApprovalStatus = Model.RatioRequirements.ApprovedForLevel6,
-                                                                               AdditionalInformation = new AdditionalInformationModel
-                                                                                                       {
-                                                                                                           AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel6,
-                                                                                                           AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel6
-                                                                                                       }
-                                                                           });
-                    }
-
-                    if (Model.RatioRequirements.ApprovedForLevel3 == QualificationApprovalStatus.Approved)
-                    {
-                        await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                           {
-                                                                               LevelText = "Level 3",
-                                                                               ApprovalStatus = Model.RatioRequirements.ApprovedForLevel3,
-                                                                               AdditionalInformation = new AdditionalInformationModel
-                                                                                                       {
-                                                                                                           AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel3,
-                                                                                                           AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel3
-                                                                                                       }
-                                                                           });
-                    }
-
-                    if (Model.RatioRequirements.ApprovedForLevel2 == QualificationApprovalStatus.Approved)
-                    {
-                        await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                           {
-                                                                               LevelText = "Level 2",
-                                                                               ApprovalStatus = Model.RatioRequirements.ApprovedForLevel2,
-                                                                               AdditionalInformation = new AdditionalInformationModel
-                                                                                                       {
-                                                                                                           AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel2,
-                                                                                                           AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel2,
-                                                                                                           ShowAdditionalInformationBodyByDefault = Model.RatioRequirements.ShowRequirementsForLevel2ByDefault
-                                                                                                       }
-                                                                           });
-                    }
-
-                    if (Model.RatioRequirements.ApprovedForUnqualified == QualificationApprovalStatus.Approved)
-                    {
-                        await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                           {
-                                                                               LevelText = "Unqualified",
-                                                                               ApprovalStatus = Model.RatioRequirements.ApprovedForUnqualified,
-                                                                               AdditionalInformation = new AdditionalInformationModel
-                                                                                                       {
-                                                                                                           AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForUnqualified,
-                                                                                                           AdditionalInformationBody = Model.RatioRequirements.RequirementsForUnqualified
-                                                                                                       }
-                                                                           });
-                    }
-                }
-
-                if (Model.RatioRequirements.ApprovedForLevel2 == QualificationApprovalStatus.NotApproved
-                    || Model.RatioRequirements.ApprovedForLevel2 == QualificationApprovalStatus.FurtherActionRequired
-                    || Model.RatioRequirements.ApprovedForLevel3 == QualificationApprovalStatus.NotApproved
-                    || Model.RatioRequirements.ApprovedForLevel3 == QualificationApprovalStatus.PossibleRouteAvailable
-                    || Model.RatioRequirements.ApprovedForLevel6 == QualificationApprovalStatus.NotApproved
-                    || Model.RatioRequirements.ApprovedForLevel6 == QualificationApprovalStatus.PossibleRouteAvailable                                                                         
-                    || Model.RatioRequirements.ApprovedForUnqualified == QualificationApprovalStatus.NotApproved)
-                {
-                    if (Model.RatioRequirements.ApprovedForUnqualified == QualificationApprovalStatus.NotApproved)
-                    {
-                        await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                           {
-                                                                               LevelText = "Unqualified",
-                                                                               ApprovalStatus = Model.RatioRequirements.ApprovedForUnqualified,
-                                                                               AdditionalInformation = new AdditionalInformationModel
-                                                                                                       {
-                                                                                                           AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForUnqualified,
-                                                                                                           AdditionalInformationBody = Model.RatioRequirements.RequirementsForUnqualified
-                                                                                                       }
-                                                                           });
-                    }
-
-                    if (Model.RatioRequirements.ApprovedForLevel2 is QualificationApprovalStatus.NotApproved or QualificationApprovalStatus.FurtherActionRequired)
-                    {
-                        await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                           {
-                                                                               LevelText = "Level 2",
-                                                                               ApprovalStatus = Model.RatioRequirements.ApprovedForLevel2,
-                                                                               AdditionalInformation = new AdditionalInformationModel
-                                                                                                       {
-                                                                                                           AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel2,
-                                                                                                           AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel2,
-                                                                                                           ShowAdditionalInformationBodyByDefault = Model.RatioRequirements.ShowRequirementsForLevel2ByDefault
-                                                                                                       }
-                                                                           });
-                    }
-
-                    if (Model.RatioRequirements.ApprovedForLevel3 is QualificationApprovalStatus.NotApproved or QualificationApprovalStatus.PossibleRouteAvailable)
-                    {
-                        await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                           {
-                                                                               LevelText = "Level 3",
-                                                                               ApprovalStatus = Model.RatioRequirements.ApprovedForLevel3,
-                                                                               AdditionalInformation = new AdditionalInformationModel
-                                                                                                       {
-                                                                                                           AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel3,
-                                                                                                           AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel3,
-                                                                                                           ShowAdditionalInformationBodyByDefault = Model.RatioRequirements.ShowRequirementsForLevel3ByDefault
-                                                                                                       }
-                                                                           });
-                    }
-
-                    if (Model.RatioRequirements.ApprovedForLevel6 is QualificationApprovalStatus.NotApproved or QualificationApprovalStatus.PossibleRouteAvailable)
-                    {
-                        await Html.RenderPartialAsync("Partials/RatioRow", new RatioRowModel
-                                                                           {
-                                                                               LevelText = "Level 6",
-                                                                               ApprovalStatus = Model.RatioRequirements.ApprovedForLevel6,
-                                                                               AdditionalInformation = new AdditionalInformationModel
-                                                                                                       {
-                                                                                                           AdditionalInformationHeader = Model.RatioRequirements.RequirementsHeadingForLevel6,
-                                                                                                           AdditionalInformationBody = Model.RatioRequirements.RequirementsForLevel6,
-                                                                                                           ShowAdditionalInformationBodyByDefault = Model.RatioRequirements.ShowRequirementsForLevel6ByDefault
-                                                                                                       }
-                                                                           });
-                    }
-                }
+            @foreach (var row in Model.OrderRatioRows())
+            {
+                await Html.RenderPartialAsync("Partials/RatioRow", row);
             }
-
+            
             <h2 class="govuk-heading-l govuk-!-static-margin-top-9"
                 id="requirements-heading">@Model.Content!.RequirementsHeading</h2>
 

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QualificationDetailsControllerTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Controllers/QualificationDetailsControllerTests.cs
@@ -584,4 +584,51 @@ public class QualificationDetailsControllerTests
         model.MessageBody.Should().Be(messageBody);
         model.IsFullAndRelevant.Should().Be(isFullAndRelevant);
     }
+    
+    [TestMethod]
+    public void SortRatioRows_OrderByQualificationApprovedStatus_ReturnsExpectedOrder()
+    {
+        var model = new QualificationDetailsModel
+                    {
+                        RatioRequirements = new RatioRequirementModel
+                                            {
+                                                ApprovedForLevel3 = QualificationApprovalStatus.Approved,
+                                                ApprovedForLevel2 = QualificationApprovalStatus.Approved,
+                                                ApprovedForLevel6 = QualificationApprovalStatus.Approved,
+                                                ApprovedForUnqualified = QualificationApprovalStatus.Approved,
+                                            }
+                    };
+        
+        var orderedRows = model.OrderRatioRows();
+            
+        orderedRows.Where(x => x.ApprovalStatus == QualificationApprovalStatus.Approved).Should().BeInDescendingOrder(x => x.Level);
+    }
+    
+    [TestMethod]
+    public void SortRatioRows_OrderByQualificationMixedtatus_ReturnsExpectedOrder()
+    {
+        var model = new QualificationDetailsModel
+                    {
+                        RatioRequirements = new RatioRequirementModel
+                                            {
+                                                ApprovedForLevel3 = QualificationApprovalStatus.PossibleRouteAvailable,
+                                                ApprovedForLevel2 = QualificationApprovalStatus.FurtherActionRequired,
+                                                ApprovedForLevel6 = QualificationApprovalStatus.NotApproved,
+                                                ApprovedForUnqualified = QualificationApprovalStatus.Approved,
+                                            }
+                    };
+        
+        var orderedRows = model.OrderRatioRows();
+      
+        orderedRows.Where(x => x.ApprovalStatus == QualificationApprovalStatus.Approved)
+                   .Should().BeInDescendingOrder(x => x.Level);
+        
+        orderedRows.Where(x => x.ApprovalStatus != QualificationApprovalStatus.Approved)
+                   .Should().BeInAscendingOrder(x => x.Level);
+
+        orderedRows.ElementAt(0).ApprovalStatus.Should().Be(QualificationApprovalStatus.Approved);
+        orderedRows.ElementAt(1).ApprovalStatus.Should().Be(QualificationApprovalStatus.FurtherActionRequired);
+        orderedRows.ElementAt(2).ApprovalStatus.Should().Be(QualificationApprovalStatus.PossibleRouteAvailable);
+        orderedRows.ElementAt(3).ApprovalStatus.Should().Be(QualificationApprovalStatus.NotApproved);
+    }
 }


### PR DESCRIPTION
# Description

Please include a summary of the changes.
Simplified the qualification result page by moving the logic that renders the ratio rows to the view model

## Ticket number (if applicable)
https://dfedigital.atlassian.net.mcas.ms/browse/feature/EYQB-1236-refactor-logic-for-qualification-page

# How Has This Been Tested?

Added unit tests to verify the order of the ratio rows

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [X] My code follows the standards used within this project
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules