### PR TITLE
EYQB-1570 removed temporary use of preview api flag

### DIFF
--- a/.github/actions/run-validation-tests-locally/action.yml
+++ b/.github/actions/run-validation-tests-locally/action.yml
@@ -19,9 +19,6 @@ inputs:
     default: "false"
   contentful_delivery_api_key:
     description: "Contentful delivery api key"
-  contentful_preview_api_key:
-    description: "Contentful preview api key"
-    required: true
   contentful_space_id:
     description: "Contentful space id"
     required: true
@@ -42,12 +39,11 @@ runs:
         USE_MOCK_CONTENTFUL: ${{ inputs.use_mock_contentful }}
         RUN_VALIDATION_TESTS: ${{ inputs.run_validation_tests }}
         CONTENTFUL_DELIVERY_API_KEY: ${{ inputs.contentful_delivery_api_key }}
-        CONTENTFUL_PREVIEW_API_KEY: ${{ inputs.contentful_preview_api_key }}
         CONTENTFUL_SPACE_ID: ${{ inputs.contentful_space_id }}
         UPGRADE_INSECURE_REQUESTS: ${{ inputs.upgrade_insecure_requests }}
 
       working-directory: ./tests/Dfe.EarlyYearsQualification.E2ETests
-      run: WEBAPP_URL=${WEBAPP_URL} DOMAIN=${WEBAPP_URL} AUTH_SECRET=${AUTH_SECRET} USE_MOCK_CONTENTFUL=${USE_MOCK_CONTENTFUL} RUN_VALIDATION_TESTS=${RUN_VALIDATION_TESTS} CONTENTFUL_DELIVERY_API_KEY=${CONTENTFUL_DELIVERY_API_KEY} CONTENTFUL_PREVIEW_API_KEY=${CONTENTFUL_PREVIEW_API_KEY} CONTENTFUL_SPACE_ID=${CONTENTFUL_SPACE_ID} UPGRADE_INSECURE_REQUESTS=${UPGRADE_INSECURE_REQUESTS} npx playwright test --grep "@${TEST_TYPE}" --project=chromium --project=firefox
+      run: WEBAPP_URL=${WEBAPP_URL} DOMAIN=${WEBAPP_URL} AUTH_SECRET=${AUTH_SECRET} USE_MOCK_CONTENTFUL=${USE_MOCK_CONTENTFUL} RUN_VALIDATION_TESTS=${RUN_VALIDATION_TESTS} CONTENTFUL_DELIVERY_API_KEY=${CONTENTFUL_DELIVERY_API_KEY} CONTENTFUL_SPACE_ID=${CONTENTFUL_SPACE_ID} UPGRADE_INSECURE_REQUESTS=${UPGRADE_INSECURE_REQUESTS} npx playwright test --grep "@${TEST_TYPE}" --project=chromium --project=firefox
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -99,7 +99,6 @@ jobs:
           use_mock_contentful: "false"
           run_validation_tests: "true"
           contentful_delivery_api_key: ${{ secrets.CONTENTFUL_DELIVERY_API_KEY }}
-          contentful_preview_api_key: ${{ secrets.CONTENTFUL_PREVIEW_API_KEY }}
           contentful_space_id: ${{ secrets.CONTENTFUL_SPACE_ID }}
 
   security-checks-local:

--- a/src/Dfe.EarlyYearsQualification.Content/Constants/QuestionPages.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Constants/QuestionPages.cs
@@ -12,7 +12,7 @@ public static class QuestionPages
     /// <summary>
     ///     Entry ID for the "What level is the qualification" question page.
     /// </summary>
-    public const string WhatLevelIsTheQualification = "9qBgm4x3OWouGvcjxuONA";
+    public const string WhatLevelIsTheQualification = "1kVHZwUaXiyGYHO4ipovYV";
 
     /// <summary>
     ///     Entry ID for the When was the qualification started page

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/playwright.config.ts
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/playwright.config.ts
@@ -90,16 +90,12 @@ function buildCommand() {
         + `--UseMockContentful="${process.env.USE_MOCK_CONTENTFUL ?? true}" `
         + `--RunValidationTests="${process.env.RUN_VALIDATION_TESTS ?? false}" `
         + `--ServiceAccess:Keys:0="${process.env.AUTH_SECRET}" `
-        + `--ContentfulOptions:UsePreviewApi="${true}" `
+        + `--ContentfulOptions:UsePreviewApi="${process.env.USE_MOCK_CONTENTFUL ?? false}" `
         + `--UpgradeInsecureRequests="${process.env.UPGRADE_INSECURE_REQUESTS ?? true}" `
         + `--ENVIRONMENT="Development" `;
 
     if (process.env.CONTENTFUL_DELIVERY_API_KEY !== undefined) {
         command += `--ContentfulOptions:DeliveryApiKey="${process.env.CONTENTFUL_DELIVERY_API_KEY}" `;
-    }
-
-    if (process.env.CONTENTFUL_PREVIEW_API_KEY !== undefined) {
-        command += `--ContentfulOptions:PreviewApiKey="${process.env.CONTENTFUL_PREVIEW_API_KEY}" `;
     }
 
     if (process.env.CONTENTFUL_SPACE_ID !== undefined) {


### PR DESCRIPTION
# Description

Added duplicate WhatLevelIsTheQualification id to make the transition with content eaiser

## Ticket number (if applicable)

https://dfedigital.atlassian.net.mcas.ms/browse/EYQB-1570

# How Has This Been Tested?

Manually ran. e2e and unit tests have ran against changes

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules