### PR TITLE
Add missing PAL metadata to deployment

### DIFF
--- a/.github/workflows/release-build-and-deploy.yml
+++ b/.github/workflows/release-build-and-deploy.yml
@@ -54,6 +54,12 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      # Ensure PAL metadata is set on the deployment principal
+      - name: Service principal metadata
+        continue-on-error: true
+        run: |
+          az rest --method put --uri "https://management.azure.com/providers/microsoft.managementpartner/partners/6084223?api-version=2018-02-01" --body '{"partnerId": "6084223"}' || true
+
       # Deploy Web Application
       - name: Deploy to Azure App Services
         uses: azure/webapps-deploy@v3


### PR DESCRIPTION
# Description

I've been talking with Microsoft account people about ensuring the correct associations are in place for partner metadata.

The deployment user should have an association with the management partner number, as subscription-level identifiers are no longer used. This enables Microsoft's tracking to differentiate between solutions partners. Per https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/link-partner-id this does not impact any access change behaviour of the services, it is purely to support Microsoft's metrics.

## Ticket number (if applicable)

N/A

# How Has This Been Tested?

None, this is a non-functional change, purely metadata

# Screenshots

N/A

# Checklist:

- [X] My code follows the standards used within this project
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules