### PR TITLE
EYQB-1677 added list of nations to qualification and filters in webview

### DIFF
--- a/src/Dfe.EarlyYearsQualification.Content/Entities/Nation.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/Nation.cs
@@ -1,0 +1,6 @@
+namespace Dfe.EarlyYearsQualification.Content.Entities;
+
+public class Nation
+{
+    public string Name { get; init; } = string.Empty;
+}

--- a/src/Dfe.EarlyYearsQualification.Content/Entities/Qualification.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/Qualification.cs
@@ -13,6 +13,7 @@ public class Qualification(
     public int QualificationLevel { get; } = qualificationLevel;
     public int StaffChildRatio { get; init; }
     public List<Tab> EyqlTabs { get; init; } = [];
+    public List<Nation> Nations { get; set; } = new List<Nation>();
 
     // Optional Fields
     public string? FromWhichYear { get; init; }

--- a/src/Dfe.EarlyYearsQualification.Content/Entities/Qualification.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/Qualification.cs
@@ -13,7 +13,7 @@ public class Qualification(
     public int QualificationLevel { get; } = qualificationLevel;
     public int StaffChildRatio { get; init; }
     public List<Tab> EyqlTabs { get; init; } = [];
-    public List<Nation> Nations { get; set; } = new List<Nation>();
+    public List<Nation> Nations { get; set; } = [];
 
     // Optional Fields
     public string? FromWhichYear { get; init; }

--- a/src/Dfe.EarlyYearsQualification.Content/Entities/WebViewPage.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/WebViewPage.cs
@@ -6,27 +6,27 @@ public class WebViewPage
 {
     public NavigationLink? BackButton { get; init; }
 
-    public string Heading  { get; init; } = string.Empty;
+    public string Heading { get; init; } = string.Empty;
 
-    public Document PostHeadingContent  { get; init; } = new Document();
+    public Document PostHeadingContent { get; init; } = new Document();
 
     public string DownloadHeading { get; init; } = string.Empty;
     
-    public Document DownloadSectionContent  { get; init; } = new Document();
+    public Document DownloadSectionContent { get; init; } = new Document();
 
-    public string DownloadButtonText  { get; init; } = string.Empty;
+    public string DownloadButtonText { get; init; } = string.Empty;
 
-    public string QualificationLevelLabel  { get; init; } = string.Empty;
+    public string QualificationLevelLabel { get; init; } = string.Empty;
 
-    public string StaffChildRatioLabel  { get; init; } = string.Empty;
+    public string StaffChildRatioLabel { get; init; } = string.Empty;
 
     public string FromWhichYearLabel { get; init; } = string.Empty;
 
     public string ToWhichYearLabel { get; init; } = string.Empty;
 
-    public string AwardingOrganisationLabel  { get; init; } = string.Empty;
+    public string AwardingOrganisationLabel { get; init; } = string.Empty;
 
-    public string QualificationNumberLabel  { get; init; } = string.Empty;
+    public string QualificationNumberLabel { get; init; } = string.Empty;
 
     public string NotesAdditionalRequirementsLabel  { get; init; } = string.Empty;
 
@@ -34,27 +34,31 @@ public class WebViewPage
 
     public Document NoQualificationsFoundContent { get; init; } = new Document();
 
-    public Document QualificationIsFullAndRelevantContent  { get; init; } = new Document();
+    public Document QualificationIsFullAndRelevantContent { get; init; } = new Document();
 
-    public string FilterHeading  { get; init; } = string.Empty;
+    public string FilterHeading { get; init; } = string.Empty;
 
-    public string SelectedFiltersHeading  { get; init; } = string.Empty;
+    public string SelectedFiltersHeading { get; init; } = string.Empty;
 
-    public string KeywordHeading  { get; init; } = string.Empty;
+    public string KeywordHeading { get; init; } = string.Empty;
 
-    public string QualificationStartDateHeading  { get; init; } = string.Empty;
+    public string QualificationStartDateHeading { get; init; } = string.Empty;
 
-    public string QualificationLevelHeading  { get; init; } = string.Empty;
+    public string QualificationLevelHeading { get; init; } = string.Empty;
 
-    public string ApplyFiltersButtonContent  { get; init; } = string.Empty;
+    public string NationHeading { get; init; } = string.Empty;
+
+    public string ApplyFiltersButtonContent { get; init; } = string.Empty;
 
     public string ClearFiltersLinkLabel { get; init; } = string.Empty;
 
-    public string NoFiltersSelectedContent  { get; init; } = string.Empty;
+    public string NoFiltersSelectedContent { get; init; } = string.Empty;
 
     public List<IOptionItem> StartDateFilters { get; init; } = [];
 
     public List<IOptionItem> LevelFilters { get; init; } = [];
+
+    public List<IOptionItem> NationFilters { get; init; } = [];
 
     public string MultipleQualificationsFoundText { get; init; } = string.Empty;
 

--- a/src/Dfe.EarlyYearsQualification.Content/Filters/IQualificationListFilter.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Filters/IQualificationListFilter.cs
@@ -5,5 +5,5 @@ namespace Dfe.EarlyYearsQualification.Content.Filters;
 public interface IQualificationListFilter
 {
     List<Qualification> ApplyFilters(List<Qualification> qualifications, int? level, int? startDateMonth,
-                                     int? startDateYear, string? awardingOrganisation, string? qualificationName);
+                                     int? startDateYear, string? awardingOrganisation, string? qualificationName, string? nation);
 }

--- a/src/Dfe.EarlyYearsQualification.Content/Filters/QualificationListFilter.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Filters/QualificationListFilter.cs
@@ -8,7 +8,7 @@ namespace Dfe.EarlyYearsQualification.Content.Filters;
 public class QualificationListFilter(IFuzzyAdapter fuzzyAdapter, IDateValidator dateValidator) : IQualificationListFilter
 {
     public List<Qualification> ApplyFilters(List<Qualification> qualifications, int? level, int? startDateMonth, int? startDateYear,
-                                            string? awardingOrganisation, string? qualificationName)
+                                            string? awardingOrganisation, string? qualificationName, string? nation)
     {
         var filteredQualifications = qualifications;
         
@@ -16,6 +16,7 @@ public class QualificationListFilter(IFuzzyAdapter fuzzyAdapter, IDateValidator 
         filteredQualifications = FilterQualificationsByAwardingOrganisation(startDateMonth, startDateYear, awardingOrganisation, filteredQualifications);
         filteredQualifications = FilterQualificationsByDate(startDateMonth, startDateYear, filteredQualifications);
         filteredQualifications = FilterQualificationsByName(filteredQualifications, qualificationName);
+        filteredQualifications = FilterQualificationsByNation(filteredQualifications, nation);
 
         return filteredQualifications;
     }
@@ -94,7 +95,16 @@ public class QualificationListFilter(IFuzzyAdapter fuzzyAdapter, IDateValidator 
 
         return matchedQualifications;
     }
-    
+
+    private static List<Qualification> FilterQualificationsByNation(List<Qualification> qualifications, string? nation)
+    {
+        if (string.IsNullOrEmpty(nation)) { 
+            return qualifications; 
+        }
+
+        return qualifications.Where(q => q.Nations.Any(n => string.Equals(n.Name.Replace(" ", "-"), nation, StringComparison.OrdinalIgnoreCase))).ToList();
+    }
+
     private static List<string> IncludeLinkedOrganisations(string awardingOrganisation, int? startDateMonth,
                                                            int? startDateYear)
     {

--- a/src/Dfe.EarlyYearsQualification.Content/Services/Interfaces/IQualificationsRepository.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/Interfaces/IQualificationsRepository.cs
@@ -7,5 +7,5 @@ public interface IQualificationsRepository
     Task<Qualification?> GetById(string qualificationId);
 
     Task<List<Qualification>> Get(int? level, int? startDateMonth, int? startDateYear,
-                                  string? awardingOrganisation, string? qualificationName);
+                                  string? awardingOrganisation, string? qualificationName, string? nation);
 }

--- a/src/Dfe.EarlyYearsQualification.Content/Services/QualificationsRepository.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Services/QualificationsRepository.cs
@@ -30,14 +30,15 @@ public class QualificationsRepository(
         return qualifications.FirstOrDefault(x => string.Equals(x.QualificationId, qualificationId, StringComparison.CurrentCultureIgnoreCase));
     }
 
-    public async Task<List<Qualification>> Get(int? level, int? startDateMonth, int? startDateYear, string? awardingOrganisation, string? qualificationName)
+    public async Task<List<Qualification>> Get(int? level, int? startDateMonth, int? startDateYear, string? awardingOrganisation, string? qualificationName, string? nation)
     {
-        Logger.LogInformation("Filtering options passed in - level: {Level}, startDateMonth: {StartDateMonth}, startDateYear: {StartDateYear}, awardingOrganisation: {AwardingOrganisation}, qualificationName: {QualificationName}",
+        Logger.LogInformation("Filtering options passed in - level: {Level}, startDateMonth: {StartDateMonth}, startDateYear: {StartDateYear}, awardingOrganisation: {AwardingOrganisation}, qualificationName: {QualificationName}, nation: {Nation}",
                               level,
                               startDateMonth,
                               startDateYear,
                               awardingOrganisation,
-                              qualificationName);
+                              qualificationName,
+                              nation);
         
         var qualifications = await GetAllQualifications();
 
@@ -48,7 +49,7 @@ public class QualificationsRepository(
 
         var filteredQualifications =
             qualificationListFilter.ApplyFilters(qualifications, level, startDateMonth, startDateYear,
-                                                    awardingOrganisation, qualificationName);
+                                                    awardingOrganisation, qualificationName, nation);
         
         return filteredQualifications;
     }

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
@@ -1165,6 +1165,7 @@ public class MockContentfulService : IContentService
                 SelectedFiltersHeading = "Selected filters",
                 KeywordHeading = "Keywords",
                 QualificationStartDateHeading = "Qualification start date",
+                NationHeading = "Qualification awarded in",
                 QualificationLevelHeading = "Qualification level",
                 ApplyFiltersButtonContent = "Apply filters",
                 NoFiltersSelectedContent = "No filters selected.",
@@ -1197,6 +1198,17 @@ public class MockContentfulService : IContentService
                     { Label = "Level 6", Value = "6" },
                     new Option
                     { Label = "Level 7", Value = "7" },
+                ],
+                NationFilters =
+                [
+                    new Option
+                    { Label = "England", Value = "england" },
+                    new Option
+                    { Label = "Scotland", Value = "scotland" },
+                    new Option
+                    { Label = "Wales", Value = "wales" },
+                    new Option
+                    { Label = "Northern Ireland", Value = "northern-ireland" },
                 ],
                 ClearFiltersLinkLabel = "Clear filters",
                 NoQualificationsFoundContent = ContentfulContentHelper.Paragraph("No qualifications match the filters you selected."),

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockQualificationsRepository.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockQualificationsRepository.cs
@@ -89,7 +89,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
     }
 
     public Task<List<Qualification>> Get(int? level, int? startDateMonth, int? startDateYear,
-                                         string? awardingOrganisation, string? qualificationName)
+                                         string? awardingOrganisation, string? qualificationName, string? nation)
     {
         const string dupeQualificationName = "dupe qualification name";
 
@@ -179,7 +179,21 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                             Heading = "Post-September 2014",
                             Order = 2
                         }
-                    ]
+                    ],
+                    Nations = [
+                        new Nation
+                        {
+                            Name = "England"
+                        },
+                        new Nation
+                        {
+                            Name = "Scotland"
+                        },
+                        new Nation
+                        {
+                            Name = "Northern Ireland"
+                        }
+                   ]
                 },
                 new Qualification("EYQ-304", "Qualification 304", AwardingOrganisations.Various, 5)
                 {
@@ -193,7 +207,21 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                             Heading = "Post-September 2014",
                             Order = 2
                         }
-                    ]
+                    ],
+                    Nations = [
+                        new Nation
+                        {
+                            Name = "England"
+                        },
+                        new Nation
+                        {
+                            Name = "Scotland"
+                        },
+                        new Nation
+                        {
+                            Name = "Northern Ireland"
+                        }
+                   ]
                 },
                 new Qualification("EYQ-305", "Qualification 305", AwardingOrganisations.Edexcel, 6)
                 {
@@ -250,7 +278,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                 },
             };
 
-        var results = qualificationListFilter.ApplyFilters(qualifications, level, startDateMonth, startDateYear, awardingOrganisation, qualificationName);
+        var results = qualificationListFilter.ApplyFilters(qualifications, level, startDateMonth, startDateYear, awardingOrganisation, qualificationName, nation);
 
         return Task.FromResult(results);
     }
@@ -308,7 +336,13 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                    FromWhichYear = startDate,
                    ToWhichYear = endDate,
                    QualificationNumber = "ghi/456/951",
-                   AdditionalRequirements = "additional requirements"
+                   AdditionalRequirements = "additional requirements",
+                   Nations = [
+                       new Nation
+                       {
+                           Name = "England"
+                       }
+                   ]
                };
     }
 
@@ -412,8 +446,14 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                                    .UnqualifiedRatioRequirementName,
                            SummaryCardDefaultContent = SummaryCardDefaultContent
                        }
+                   ],
+                   Nations = [
+                       new Nation
+                       {
+                           Name = "England"
+                       }
                    ]
-               };
+        };
     }
 
     private static Qualification CreateQtsQualification(string qualificationId, string qualificationName,
@@ -519,7 +559,13 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                            SummaryCardDefaultContent = SummaryCardDefaultContent
                        }
                    ],
-                   IsAutomaticallyApprovedAtLevel6 = false
+                   IsAutomaticallyApprovedAtLevel6 = false,
+                   Nations = [
+                       new Nation
+                       {
+                           Name = "England"
+                       }
+                   ]
                };
     }
 

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockQualificationsRepository.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockQualificationsRepository.cs
@@ -120,13 +120,27 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                 {
                     FromWhichYear = startDate,
                     ToWhichYear = endDate,
-                    QualificationNumber = "123/345/678"
+                    QualificationNumber = "123/345/678",
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        }
+                    ]
                 },
                 new Qualification("EYQ-115", dupeQualificationName, AwardingOrganisations.Ncfe, 3)
                 {
                     FromWhichYear = startDate,
                     ToWhichYear = endDate,
-                    QualificationNumber = "233/420/12"
+                    QualificationNumber = "233/420/12",
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        }
+                    ]
                 },
                 CreateQualification("EYQ-240",
                                     "T Level Technical Qualification in Education and Childcare (Specialism - Early Years Educator)",
@@ -151,6 +165,13 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                             Heading = "Pre-September 2014",
                             Order = 1
                         }
+                    ],
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        }
                     ]
                 },
                 new Qualification("EYQ-302", "Qualification 302", AwardingOrganisations.Pearson, 3)
@@ -164,6 +185,13 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                         {
                             Heading = "Pre-September 2014",
                             Order = 1
+                        }
+                    ],
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
                         }
                     ]
                 },
@@ -236,6 +264,21 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                             Order = 2
                         }
 
+                    ],
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        },
+                        new Nation
+                        {
+                            Name = "Scotland"
+                        },
+                        new Nation
+                        {
+                            Name = "Northern Ireland"
+                        }
                     ]
                 },
                 new Qualification("EYQ-306", "Qualification 306", AwardingOrganisations.Various, 7)
@@ -250,31 +293,70 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                             Heading = "Post-September 2024",
                             Order = 3
                         }
+                    ],
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        },
+                        new Nation
+                        {
+                            Name = "Scotland"
+                        }
                     ]
                 },
                 new Qualification("EYQ-307", "Degrees at level 6", AwardingOrganisations.Ncfe, 3)
                 {
                     FromWhichYear = startDate,
                     ToWhichYear = endDate,
-                    QualificationNumber = "123/345/679"
+                    QualificationNumber = "123/345/679",
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        }
+                    ]
                 },
                 new Qualification("EYQ-308", "Joint degrees at level 6", AwardingOrganisations.Ncfe, 3)
                 {
                     FromWhichYear = startDate,
                     ToWhichYear = endDate,
-                    QualificationNumber = "123/345/670"
+                    QualificationNumber = "123/345/670",
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        }
+                    ]
                 },
                 new Qualification("EYQ-309", dupeQualificationName, AwardingOrganisations.Ncfe, 3)
                 {
                     FromWhichYear = startDate,
                     ToWhichYear = endDate,
-                    QualificationNumber = "321/345/679"
+                    QualificationNumber = "321/345/679",
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        }
+                    ]
                 },
                 new Qualification("EYQ-310", dupeQualificationName, AwardingOrganisations.Ncfe, 3)
                 {
                     FromWhichYear = startDate,
                     ToWhichYear = endDate,
-                    QualificationNumber = "231/345/670"
+                    QualificationNumber = "231/345/670",
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        }
+                    ]
                 },
             };
 
@@ -321,7 +403,14 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                                }
                            ]
                        }
-                   ]
+                    ],
+                    Nations =
+                    [
+                        new Nation
+                        {
+                            Name = "England"
+                        }
+                    ]
                };
     }
 

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockQualificationsRepository.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockQualificationsRepository.cs
@@ -9,6 +9,10 @@ namespace Dfe.EarlyYearsQualification.Mock.Content;
 
 public class MockQualificationsRepository(IQualificationListFilter qualificationListFilter) : IQualificationsRepository
 {
+    private const string englandNation = "England";
+    private const string scotlandNation = "Scotland";
+    private const string northernIrelandNation = "Northern Ireland";
+
     public async Task<Qualification?> GetById(string qualificationId)
     {
         var degreeQualification = CreateQtsQualification("EYQ-321", "NCFE",
@@ -125,7 +129,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         }
                     ]
                 },
@@ -138,7 +142,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         }
                     ]
                 },
@@ -170,7 +174,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         }
                     ]
                 },
@@ -191,7 +195,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         }
                     ]
                 },
@@ -211,15 +215,15 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     Nations = [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         },
                         new Nation
                         {
-                            Name = "Scotland"
+                            Name = scotlandNation
                         },
                         new Nation
                         {
-                            Name = "Northern Ireland"
+                            Name = northernIrelandNation
                         }
                    ]
                 },
@@ -239,15 +243,15 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     Nations = [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         },
                         new Nation
                         {
-                            Name = "Scotland"
+                            Name = scotlandNation
                         },
                         new Nation
                         {
-                            Name = "Northern Ireland"
+                            Name = northernIrelandNation
                         }
                    ]
                 },
@@ -269,15 +273,15 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         },
                         new Nation
                         {
-                            Name = "Scotland"
+                            Name = scotlandNation
                         },
                         new Nation
                         {
-                            Name = "Northern Ireland"
+                            Name = northernIrelandNation
                         }
                     ]
                 },
@@ -298,11 +302,11 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         },
                         new Nation
                         {
-                            Name = "Scotland"
+                            Name = scotlandNation
                         }
                     ]
                 },
@@ -315,7 +319,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         }
                     ]
                 },
@@ -328,7 +332,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         }
                     ]
                 },
@@ -341,7 +345,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         }
                     ]
                 },
@@ -354,7 +358,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         }
                     ]
                 },
@@ -408,7 +412,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                     [
                         new Nation
                         {
-                            Name = "England"
+                            Name = englandNation
                         }
                     ]
                };
@@ -429,7 +433,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                    Nations = [
                        new Nation
                        {
-                           Name = "England"
+                           Name = englandNation
                        }
                    ]
                };
@@ -539,7 +543,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                    Nations = [
                        new Nation
                        {
-                           Name = "England"
+                           Name = englandNation
                        }
                    ]
         };
@@ -652,7 +656,7 @@ public class MockQualificationsRepository(IQualificationListFilter qualification
                    Nations = [
                        new Nation
                        {
-                           Name = "England"
+                           Name = englandNation
                        }
                    ]
                };

--- a/src/Dfe.EarlyYearsQualification.Web/Mappers/WebViewMapper.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Mappers/WebViewMapper.cs
@@ -29,6 +29,7 @@ public class WebViewMapper(IGovUkContentParser contentParser) : IWebViewPageMapp
             QualificationLevelFilter = webViewFilters.QualificationLevel,
             QualificationStartDateFilter = webViewFilters.QualificationStartDate,
             SearchTermFilter = webViewFilters.SearchTerm,
+            NationFilter = webViewFilters.Nation,
             NoQualificationsFoundContent = await contentParser.ToHtml(content.NoQualificationsFoundContent),
             CheckIfAnEarlyYearsQualificationIsFullAndRelevantContent = await contentParser.ToHtml(content.QualificationIsFullAndRelevantContent),
             ApplyFiltersButtonContent = content.ApplyFiltersButtonContent,
@@ -38,9 +39,11 @@ public class WebViewMapper(IGovUkContentParser contentParser) : IWebViewPageMapp
             KeywordHeading = content.KeywordHeading,
             QualificationStartDateHeading = content.QualificationStartDateHeading,
             QualificationLevelHeading = content.QualificationLevelHeading,
+            NationHeading = content.NationHeading,
             NoFiltersSelectedContent = content.NoFiltersSelectedContent,
             StartDateFilters = OptionItemMapper.Map(content.StartDateFilters),
-            LevelFilters = OptionItemMapper.Map(content.LevelFilters)
+            LevelFilters = OptionItemMapper.Map(content.LevelFilters),
+            NationFilters = OptionItemMapper.Map(content.NationFilters),
         };
 
         model.ShowingAllQualificationsLabel = model.HasFilters ? $"{qualifications.Count} {(qualifications.Count == 1 ? content.SingleQualificationFoundText : content.MultipleQualificationsFoundText)}" : content.ShowingAllQualificationsLabel;

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/EarlyYearsQualificationListModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/EarlyYearsQualificationListModel.cs
@@ -53,6 +53,8 @@ public class EarlyYearsQualificationListModel
 
     public string QualificationLevelHeading { get; init; } = string.Empty;
 
+    public string NationHeading { get; init; } = string.Empty;
+
     public string ApplyFiltersButtonContent { get; init; } = string.Empty;
 
     public string ClearFiltersLinkLabel { get; init; } = string.Empty;
@@ -64,9 +66,13 @@ public class EarlyYearsQualificationListModel
 
     public List<IOptionItemModel> LevelFilters { get; set; } = [];
 
+    public List<IOptionItemModel> NationFilters { get; set; } = [];
+
     public string QualificationLevelFilter { get; init; } = string.Empty;
 
     public string QualificationStartDateFilter { get; init; } = string.Empty;
+
+    public string NationFilter { get; init; } = string.Empty;
 
     public string SearchTermFilter { get; init; } = string.Empty;
 
@@ -76,7 +82,8 @@ public class EarlyYearsQualificationListModel
         {
             return !string.IsNullOrWhiteSpace(SearchTermFilter) ||
                    !string.IsNullOrWhiteSpace(QualificationStartDateFilter) ||
-                   !string.IsNullOrWhiteSpace(QualificationLevelFilter);
+                   !string.IsNullOrWhiteSpace(QualificationLevelFilter) ||
+                   !string.IsNullOrWhiteSpace(NationFilter);
         }
     }
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/QualificationWebViewModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/QualificationWebViewModel.cs
@@ -14,6 +14,7 @@ public class QualificationWebViewModel : BasicQualificationModel
         StaffChildRatio = qualification.StaffChildRatio;
         QualificationNumber = string.IsNullOrEmpty(QualificationNumber) ? MissingValue : QualificationNumber;
         EyqlTabs = qualification.EyqlTabs;
+        Nations = qualification.Nations;
     }
 
     public int StaffChildRatio { get; init; }
@@ -25,6 +26,8 @@ public class QualificationWebViewModel : BasicQualificationModel
     public string? AdditionalRequirements { get; init; }
 
     public List<Tab> EyqlTabs { get; init; }
+
+    public List<Nation> Nations { get; init; }
 
     private static string FormatYearContent(string? year)
     {

--- a/src/Dfe.EarlyYearsQualification.Web/Services/QualificationSearch/QualificationSearchService.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/QualificationSearch/QualificationSearchService.cs
@@ -43,7 +43,8 @@ public class QualificationSearchService(
                                                   startDateMonth,
                                                   startDateYear,
                                                   awardingOrganisation,
-                                                  searchCriteria
+                                                  searchCriteria,
+                                                  null
                                                  );
 
         // Not in list has been selected so we need to filter out qualifications with specific awarding organisations

--- a/src/Dfe.EarlyYearsQualification.Web/Services/Questions/QuestionService.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/Questions/QuestionService.cs
@@ -131,7 +131,7 @@ public class QuestionService(
     {
         var level = userJourneyCookieService.GetLevelOfQualification();
         var (startDateMonth, startDateYear) = userJourneyCookieService.GetWhenWasQualificationStarted();
-        return await repository.Get(level, startDateMonth, startDateYear, null, null);
+        return await repository.Get(level, startDateMonth, startDateYear, null, null, null);
     }
 
     public async Task<DropdownQuestionModel> MapDropdownModel(DropdownQuestionModel model,

--- a/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/WebViewFilters.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/UserJourneyCookieService/WebViewFilters.cs
@@ -7,5 +7,7 @@
         public string QualificationStartDate { get; set; } = string.Empty;
 
         public string QualificationLevel { get; set; } = string.Empty;
+
+        public string Nation { get; set; } = string.Empty;
     }
 }

--- a/src/Dfe.EarlyYearsQualification.Web/Services/WebView/WebViewService.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Services/WebView/WebViewService.cs
@@ -33,13 +33,15 @@ public class WebViewService(
     {
         var searchCriteria = string.IsNullOrWhiteSpace(filters.SearchTerm) ? null : filters.SearchTerm;
         var qualificationLevel = GetQualificationLevel(filters.QualificationLevel);
+        var nation = GetNation(filters.Nation);
 
         var qualifications = await qualificationsRepository.Get(
                                                   qualificationLevel,
                                                   null,
                                                   null,
                                                   null,
-                                                  searchCriteria
+                                                  searchCriteria,
+                                                  nation
                                                  );
 
         qualifications = FilterQualificationsByStartDate(qualifications, filters.QualificationStartDate);
@@ -55,6 +57,7 @@ public class WebViewService(
         filters.SearchTerm = model.SearchTermFilter;
         filters.QualificationStartDate = model.QualificationStartDateFilter;
         filters.QualificationLevel = model.QualificationLevelFilter;
+        filters.Nation = model.NationFilter;
         SetWebViewFilters(filters);
     }
 
@@ -62,6 +65,14 @@ public class WebViewService(
     {
         var filters = GetWebViewFilters();
 
+        if (filter.Contains("search-term"))
+        {
+            filters.SearchTerm = string.Empty;
+        }
+        if (filter.Contains("nation"))
+        {
+            filters.Nation = string.Empty;
+        }
         if (filter.Contains("qualification-level"))
         {
             filters.QualificationLevel = string.Empty;
@@ -69,10 +80,6 @@ public class WebViewService(
         if (filter.Contains("start-date"))
         {
             filters.QualificationStartDate = string.Empty;
-        }
-        if (filter.Contains("search-term"))
-        {
-            filters.SearchTerm = string.Empty;
         }
 
         SetWebViewFilters(filters);
@@ -93,6 +100,16 @@ public class WebViewService(
         if (!string.IsNullOrWhiteSpace(qualificationLevel) && int.TryParse(qualificationLevel, out var parsedQualificationLevel))
         {
             return parsedQualificationLevel;
+        }
+
+        return null;
+    }
+
+    private static string? GetNation(string nation)
+    {
+        if (!string.IsNullOrWhiteSpace(nation))
+        {
+            return nation;
         }
 
         return null;

--- a/src/Dfe.EarlyYearsQualification.Web/Views/QualificationList/Index.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/QualificationList/Index.cshtml
@@ -54,6 +54,14 @@
                                 <span class="close-btn">&times;</span>
                             </button>
                         }
+                        @if (!string.IsNullOrEmpty(Model.NationFilter))
+                        {
+                            <h3 class="govuk-heading-s govuk-!-margin-bottom-2">@Model.NationHeading</h3>
+                            <button class="filter__button-active govuk-body" name="removeFilter" value="nation-@Model.NationFilter" aria-description="Remove nation @Model.NationFilter filter">
+                                <span class="filter__button-active-text">@(Model.NationFilters.OfType<OptionModel>().First(x => x.Value == Model.NationFilter).Label)</span>
+                                <span class="close-btn">&times;</span>
+                            </button>
+                        }
                         @if (!string.IsNullOrEmpty(Model.QualificationStartDateFilter))
                         {
                             <h3 class="govuk-heading-s govuk-!-margin-bottom-2">@Model.QualificationStartDateHeading</h3>
@@ -91,6 +99,24 @@
                             @Model.KeywordHeading
                         </label>
                         <input class="govuk-input" asp-for="SearchTermFilter" autocomplete="off" />
+                    </div>
+                    <div class="filter__filter-body__section">
+                        <govuk-radios for="NationFilter">
+                            <govuk-radios-fieldset class="govuk-radios govuk-radios--small">
+                                <govuk-radios-fieldset-legend is-page-heading="false" class="govuk-fieldset__legend--m">
+                                    @Model.NationHeading
+                                </govuk-radios-fieldset-legend>
+                                @foreach (var radio in Model.NationFilters)
+                                {
+                                    if (radio is OptionModel optionModel)
+                                    {
+                                        <govuk-radios-item value="@optionModel.Value">
+                                            @optionModel.Label
+                                        </govuk-radios-item>
+                                    }
+                                }
+                            </govuk-radios-fieldset>
+                        </govuk-radios>
                     </div>
                     <div class="filter__filter-body__section">
                         <govuk-radios for="QualificationStartDateFilter">

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/tests/e2e/pages/webview.spec.ts
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/tests/e2e/pages/webview.spec.ts
@@ -26,11 +26,16 @@ test.describe("A spec that tests the webview page", {tag: "@e2e"}, () => {
         await checkText(page, ".filter__selected-filters h2.govuk-heading-m", "Selected filters");
         await checkText(page, ".filter__selected-filters h2.govuk-heading-m ~ p", "No filters selected.");
         await checkText(page, "#apply-filter-form label[for='SearchTermFilter']", "Keywords");
-        await checkText(page, "#apply-filter-form div:nth-child(2) legend", "Qualification start date");
+        await checkText(page, "#apply-filter-form div:nth-child(2) legend", "Qualification awarded in");
+        await checkText(page, "input[value='england'] ~ label", "England");
+        await checkText(page, "input[value='scotland'] ~ label", "Scotland");
+        await checkText(page, "input[value='wales'] ~ label", "Wales");
+        await checkText(page, "input[value='northern-ireland'] ~ label", "Northern Ireland");
+        await checkText(page, "#apply-filter-form div:nth-child(3) legend", "Qualification start date");
         await checkText(page, "input[value='Pre-September 2014'] ~ label", "Before September 2014");
         await checkText(page, "input[value='Post-September 2014'] ~ label","On or after September 2014");
         await checkText(page, "input[value='Post-September 2024'] ~ label", "On or after September 2024");
-        await checkText(page, "#apply-filter-form div:nth-child(3) legend", "Qualification level");
+        await checkText(page, "#apply-filter-form div:nth-child(4) legend", "Qualification level");
         await checkText(page, "input[value='2'] ~ label", "Level 2");
         await checkText(page, "input[value='3'] ~ label", "Level 3");
         await checkText(page, "input[value='4'] ~ label", "Level 4");
@@ -47,7 +52,42 @@ test.describe("A spec that tests the webview page", {tag: "@e2e"}, () => {
         await checkTextContains(page, "button[value^='search-term']", "Education and Childcare (Specialism - Early Years Educator)");
         await checkText(page, "#qualification-webview-results > h2", "1 qualification found");
         await checkText(page, "#qualification-webview-results .govuk-summary-card h2", "T Level Technical Qualification in Education and Childcare (Specialism - Early Years Educator)");
-    }); 
+     });
+
+    [
+        {
+            nation: 'england',
+            expectedNationText: 'England',
+            expectedQualificationsCount: 20,
+        },
+        {
+            nation: 'scotland',
+            expectedNationText: 'Scotland',
+            expectedQualificationsCount: 2,
+        },
+        {
+            nation: 'wales',
+            expectedNationText: 'Wales',
+            expectedQualificationsCount: 0,
+        },
+        {
+            nation: 'northern-ireland',
+            expectedNationText: 'Northern Ireland',
+            expectedQualificationsCount: 2,
+        },
+    ].forEach((scenario) => {
+        test(`Check qualifications meet criteria based on nation filter ${scenario.nation}`, async ({ page }) => {
+            await page.locator(`input[value='${scenario.nation}']`).click();
+            await page.locator("#apply-filter-form button").click();
+            await checkUrl(page, "/early-years-qualification-list");
+            await checkTextContains(page, "button[value^='nation']", scenario.expectedNationText);
+
+            const rows = page.locator('.govuk-summary-card .govuk-summary-card__content > dl > div:nth-child(3) dd');
+            const allRows = await rows.all();
+
+            expect(allRows.length).toBe(scenario.expectedQualificationsCount);
+        });
+    });
 
     test("Filter Pre-September 2014 is selected, qualifications started before Sept 2014 are returned", async ({page}) => {
         await page.locator("input[value='Pre-September 2014']").click();
@@ -125,17 +165,20 @@ test.describe("A spec that tests the webview page", {tag: "@e2e"}, () => {
 
     test(`All filters are removed when the remove filters link is selected`, async ({ page }) => {
         await inputText(page, "#SearchTermFilter", "Qualification");
+        await page.locator(`input[value='england']`).click();
         await page.locator(`input[value='Post-September 2014']`).click();
         await page.locator(`[value='5']`).click();
         await page.locator("#apply-filter-form button").click();
         await checkUrl(page, "/early-years-qualification-list");
         await checkTextContains(page, "button[value^='search-term']", "Qualification");
+        await checkTextContains(page, "button[value^='nation']", "England");
         await checkTextContains(page, "button[value^='start-date']", "On or after September 2014");
         await checkTextContains(page, "button[value^='qualification-level']", `5`);
         await checkText(page, "#qualification-webview-results > h2", "1 qualification found");
         await page.locator(`a[href='/clear-filters']`).click();
         await checkText(page, "#qualification-webview-results > h2", "Showing all the qualifications");
         await doesNotExist(page, `button[value^='search-term']`);
+        await doesNotExist(page, `button[value^='nation']`);
         await doesNotExist(page, `button[value^='start-date']`);
         await doesNotExist(page, `button[value^='qualification-level']`);
     });
@@ -150,15 +193,22 @@ test.describe("A spec that tests the webview page", {tag: "@e2e"}, () => {
 
     test(`Individual filters are removed when the active filter is selected`, async ({ page }) => {
         await inputText(page, "#SearchTermFilter", "Qualification");
+        await page.locator(`input[value='england']`).click();
         await page.locator(`input[value='Post-September 2014']`).click();
         await page.locator(`[value='5']`).click();
         await page.locator("#apply-filter-form button").click();
         await checkUrl(page, "/early-years-qualification-list");
         await checkTextContains(page, "button[value^='search-term']", "Qualification");
+        await checkTextContains(page, "button[value^='nation']", "England");
         await checkTextContains(page, "button[value^='start-date']", "On or after September 2014");
         await checkTextContains(page, "button[value^='qualification-level']", `5`);
         await page.locator("button[value^='search-term']").click();
         await doesNotExist(page, `button[value^='search-term']`);
+        await checkTextContains(page, "button[value^='nation']", "England");
+        await checkTextContains(page, "button[value^='start-date']", "On or after September 2014");
+        await checkTextContains(page, "button[value^='qualification-level']", `5`);
+        await page.locator("button[value^='nation']").click();
+        await doesNotExist(page, `button[value^='nation']`);
         await checkTextContains(page, "button[value^='start-date']", "On or after September 2014");
         await checkTextContains(page, "button[value^='qualification-level']", `5`);
         await page.locator("button[value^='start-date']").click();

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/tests/e2e/pages/webview.spec.ts
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/tests/e2e/pages/webview.spec.ts
@@ -85,7 +85,7 @@ test.describe("A spec that tests the webview page", {tag: "@e2e"}, () => {
             const rows = page.locator('.govuk-summary-card .govuk-summary-card__content > dl > div:nth-child(3) dd');
             const allRows = await rows.all();
 
-            expect(allRows.length).toBe(scenario.expectedQualificationsCount);
+            expect(allRows).toHaveLength(scenario.expectedQualificationsCount)
         });
     });
 

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/tests/e2e/pages/webview.spec.ts
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/tests/e2e/pages/webview.spec.ts
@@ -58,12 +58,12 @@ test.describe("A spec that tests the webview page", {tag: "@e2e"}, () => {
         {
             nation: 'england',
             expectedNationText: 'England',
-            expectedQualificationsCount: 20,
+            expectedQualificationsCount: 31,
         },
         {
             nation: 'scotland',
             expectedNationText: 'Scotland',
-            expectedQualificationsCount: 2,
+            expectedQualificationsCount: 4,
         },
         {
             nation: 'wales',
@@ -73,7 +73,7 @@ test.describe("A spec that tests the webview page", {tag: "@e2e"}, () => {
         {
             nation: 'northern-ireland',
             expectedNationText: 'Northern Ireland',
-            expectedQualificationsCount: 2,
+            expectedQualificationsCount: 3,
         },
     ].forEach((scenario) => {
         test(`Check qualifications meet criteria based on nation filter ${scenario.nation}`, async ({ page }) => {

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Filters/QualificationListFilterTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Filters/QualificationListFilterTests.cs
@@ -567,4 +567,41 @@ public class QualificationListFilterTests
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");
     }
+
+    [TestMethod]
+    public void ApplyFilters_PassInNation_ReturnsQualificationsForMatchingNation()
+    {
+        var qualifications = new List<Qualification>
+                             {
+                                 new Qualification("EYQ-123",
+                                                   "test",
+                                                   AwardingOrganisations.Ncfe,
+                                                   4)
+                                 {
+                                     Nations = new List<Nation>
+                                               {
+                                                   new() { Name = "Northern Ireland" }
+                                               }
+                                 },
+                                 new Qualification("EYQ-124",
+                                                   "test",
+                                                   AwardingOrganisations.Pearson,
+                                                   3)
+                                 {
+                                     Nations = new List<Nation>
+                                               {
+                                                   new() { Name = "England" }
+                                               }
+                                 }
+                             };
+
+        var mockFuzzyAdapter = new Mock<IFuzzyAdapter>();
+        var mockDateValidator = new Mock<IDateValidator>();
+        var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
+
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null, null, null, "northern-ireland");
+
+        result.Count.Should().Be(1);
+        result[0].QualificationId.Should().Be("EYQ-123");
+    }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Filters/QualificationListFilterTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Filters/QualificationListFilterTests.cs
@@ -40,7 +40,7 @@ public class QualificationListFilterTests
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
         
         var filteredQualifications =
-            qualificationFilterFactory.ApplyFilters(qualifications, null, null, null, null, null);
+            qualificationFilterFactory.ApplyFilters(qualifications, null, null, null, null, null, null);
 
         filteredQualifications.Should().NotBeNull();
         filteredQualifications.Count.Should().Be(2);
@@ -68,7 +68,7 @@ public class QualificationListFilterTests
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
         
         var result =
-            qualificationFilterFactory.ApplyFilters(qualifications, 4, null, null, null, null);
+            qualificationFilterFactory.ApplyFilters(qualifications, 4, null, null, null, null, null);
 
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");
@@ -94,7 +94,7 @@ public class QualificationListFilterTests
         var mockFuzzyAdapter = new Mock<IFuzzyAdapter>();
         var mockDateValidator = new Mock<IDateValidator>();
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null,AwardingOrganisations.Edexcel, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null, AwardingOrganisations.Edexcel, null, null);
 
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");
@@ -120,7 +120,7 @@ public class QualificationListFilterTests
         var mockFuzzyAdapter = new Mock<IFuzzyAdapter>();
         var mockDateValidator = new Mock<IDateValidator>();
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null,AwardingOrganisations.Pearson, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null, AwardingOrganisations.Pearson, null, null);
 
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");
@@ -154,7 +154,7 @@ public class QualificationListFilterTests
             .Setup(x => x.ValidateDateEntry(It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
                                             It.IsAny<Qualification>())).Returns(expectedResult);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2015,AwardingOrganisations.Cache, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2015, AwardingOrganisations.Cache, null, null);
 
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");
@@ -188,7 +188,7 @@ public class QualificationListFilterTests
             .Setup(x => x.ValidateDateEntry(It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
                                             It.IsAny<Qualification>())).Returns(expectedResult);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2013,AwardingOrganisations.Cache, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2013, AwardingOrganisations.Cache, null, null);
 
         result.Count.Should().Be(0);
     }
@@ -221,7 +221,7 @@ public class QualificationListFilterTests
             .Setup(x => x.ValidateDateEntry(It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
                                             It.IsAny<Qualification>())).Returns(expectedResult);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2015,AwardingOrganisations.Ncfe, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2015, AwardingOrganisations.Ncfe, null, null);
 
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");
@@ -255,7 +255,7 @@ public class QualificationListFilterTests
             .Setup(x => x.ValidateDateEntry(It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
                                             It.IsAny<Qualification>())).Returns(expectedResult);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2013,AwardingOrganisations.Ncfe, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2013, AwardingOrganisations.Ncfe, null, null);
 
         result.Count.Should().Be(0);
     }
@@ -288,7 +288,7 @@ public class QualificationListFilterTests
             .Setup(x => x.ValidateDateEntry(It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
                                             It.IsAny<Qualification>())).Returns(expectedResult);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null,AwardingOrganisations.Ncfe, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null, AwardingOrganisations.Ncfe, null, null);
 
         result.Count.Should().Be(0);
     }
@@ -321,7 +321,7 @@ public class QualificationListFilterTests
             .Setup(x => x.ValidateDateEntry(It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(),
                                             It.IsAny<Qualification>())).Returns(expectedResult);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null,AwardingOrganisations.Cache, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null, AwardingOrganisations.Cache, null, null);
 
         result.Count.Should().Be(0);
     }
@@ -347,7 +347,7 @@ public class QualificationListFilterTests
         var mockDateValidator = new Mock<IDateValidator>();
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
 
-        var result = qualificationFilterFactory.ApplyFilters(qualifications,null, null, null, AwardingOrganisations.Ncfe, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications,null, null, null, AwardingOrganisations.Ncfe, null, null);
 
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");
@@ -374,7 +374,7 @@ public class QualificationListFilterTests
         var mockDateValidator = new Mock<IDateValidator>();
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
 
-        var result = qualificationFilterFactory.ApplyFilters(qualifications,null, null, null, AwardingOrganisations.Ncfe, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications,null, null, null, AwardingOrganisations.Ncfe, null, null);
 
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");
@@ -401,7 +401,7 @@ public class QualificationListFilterTests
         var mockDateValidator = new Mock<IDateValidator>();
         mockDateValidator.Setup(x => x.GetDay()).Returns(28);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2013,null, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, 1, 2013,null, null, null);
 
         result.Should().BeEmpty();
     }
@@ -446,7 +446,7 @@ public class QualificationListFilterTests
         var mockDateValidator = new Mock<IDateValidator>();
         mockDateValidator.Setup(x => x.GetDay()).Returns(28);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null,null, qualificationSearch);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null, null, qualificationSearch, null);
 
         result.Should().NotBeNull();
         result.Count.Should().Be(1);
@@ -492,7 +492,7 @@ public class QualificationListFilterTests
         var mockDateValidator = new Mock<IDateValidator>();
         mockDateValidator.Setup(x => x.GetDay()).Returns(28);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
-        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null,null, qualificationSearch);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications, null, null, null, null, qualificationSearch, null);
 
         result.Should().BeEmpty();
     }
@@ -527,7 +527,7 @@ public class QualificationListFilterTests
         
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
 
-        var result = qualificationFilterFactory.ApplyFilters(qualifications,4,09, 2024, AwardingOrganisations.Ncfe, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications,4,09, 2024, AwardingOrganisations.Ncfe, null, null);
 
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");
@@ -562,7 +562,7 @@ public class QualificationListFilterTests
                                             It.IsAny<Qualification>())).Returns(expectedResult);
         var qualificationFilterFactory = new QualificationListFilter(mockFuzzyAdapter.Object, mockDateValidator.Object);
 
-        var result = qualificationFilterFactory.ApplyFilters(qualifications,4, 08, 2019, AwardingOrganisations.Ncfe, null);
+        var result = qualificationFilterFactory.ApplyFilters(qualifications,4, 08, 2019, AwardingOrganisations.Ncfe, null, null);
 
         result.Count.Should().Be(1);
         result[0].QualificationId.Should().Be("EYQ-123");

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockQualificationsRepositoryTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockQualificationsRepositoryTests.cs
@@ -16,12 +16,22 @@ public class MockQualificationsRepositoryTests
                                              It.IsAny<int?>(),
                                              It.IsAny<int?>(),
                                              It.IsAny<string?>(),
+                                             It.IsAny<string?>(),
                                              It.IsAny<string?>()))
-                 .Returns((List<Qualification> q, int? level, int? m, int? y, string? ao, string? name) =>
-                              level is > 0
-                                  ? q.Where(x => x.QualificationLevel == level).ToList()
-                                  : q);
+                 .Returns((List<Qualification> q, int? level, int? m, int? y, string? ao, string? name, string? nation) =>
+                 {
+                    var filtered = level is > 0
+                        ? q.Where(x => x.QualificationLevel == level)
+                        : q;
 
+                    if (!string.IsNullOrEmpty(nation))
+                    {
+                        filtered = filtered.Where(x => x.Nations.Any(n => nation.Equals(n.Name.Replace(" ", "-"), StringComparison.OrdinalIgnoreCase)));
+                    }
+
+                    return filtered.ToList();
+                 });
+                              
         return new MockQualificationsRepository(mockFilter.Object);
     }
 
@@ -47,6 +57,7 @@ public class MockQualificationsRepositoryTests
                                  null,
                                  null,
                                  null,
+                                 null,
                                  null);
 
         results.Count.Should().Be(expectedQualificationIds.Length);
@@ -58,7 +69,7 @@ public class MockQualificationsRepositoryTests
     public async Task GetFilteredQualifications_PassInLevel3_ReturnsQualificationWithAdditionalRequirementQuestions()
     {
         var repository = CreateRepository();
-        var results = await repository.Get(3, null, null, null, null);
+        var results = await repository.Get(3, null, null, null, null, null);
 
         var qualificationWithAdditionalRequirements =
             results.FirstOrDefault(q => q.QualificationId == "EYQ-909");
@@ -851,5 +862,26 @@ public class MockQualificationsRepositoryTests
         answers[0].Value.Should().Be("yes");
         answers[1].Label.Should().Be("No");
         answers[1].Value.Should().Be("no");
+    }
+
+    [TestMethod]
+    [DataRow("England", 31)]
+    [DataRow("Scotland", 4)]
+    [DataRow("Wales", 0)]
+    [DataRow("northern-ireland", 3)]
+    public async Task GetFilteredQualifications_PassInNation_ReturnsExpectedQualifications(
+    string nation, int expectedQualificationCount)
+    {
+        var repository = CreateRepository();
+
+        var results =
+            await repository.Get(null,
+                                 null,
+                                 null,
+                                 null,
+                                 null,
+                                 nation);
+
+        results.Count.Should().Be(expectedQualificationCount);
     }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Models/Content/EarlyYearsQualificationListModelTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Models/Content/EarlyYearsQualificationListModelTests.cs
@@ -42,6 +42,25 @@ public class EarlyYearsQualificationListModelTests
     }
 
     [TestMethod]
+    public void HasFilters_NationFilterSet_ReturnsTrue()
+    {
+        // Arrange
+        var model = new EarlyYearsQualificationListModel
+        {
+            SearchTermFilter = string.Empty,
+            QualificationStartDateFilter = string.Empty,
+            QualificationLevelFilter = string.Empty,
+            NationFilter = "Wales"
+        };
+
+        // Act
+        var result = model.HasFilters;
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [TestMethod]
     public void HasFilters_QualificationStartDateFilterSet_ReturnsTrue()
     {
         // Arrange
@@ -153,6 +172,25 @@ public class EarlyYearsQualificationListModelTests
             SearchTermFilter = string.Empty,
             QualificationStartDateFilter = string.Empty,
             QualificationLevelFilter = "   "
+        };
+
+        // Act
+        var result = model.HasFilters;
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void HasFilters_WhitespaceNationFilter_ReturnsFalse()
+    {
+        // Arrange
+        var model = new EarlyYearsQualificationListModel
+        {
+            SearchTermFilter = string.Empty,
+            QualificationStartDateFilter = string.Empty,
+            QualificationLevelFilter = string.Empty,
+            NationFilter = "   "
         };
 
         // Act

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/QualificationSearchServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/QualificationSearchServiceTests.cs
@@ -78,7 +78,7 @@ public class QualificationSearchServiceTests
     public async Task GetQualifications_GotList_Calls_Repository_Get()
     {
         _mockContentService.Setup(o => o.GetQualificationListPage()).ReturnsAsync(new QualificationListPage());
-        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
                        .ReturnsAsync([]);
         var sut = GetSut();
         await sut.GetQualifications();
@@ -88,6 +88,7 @@ public class QualificationSearchServiceTests
                                           It.IsAny<int?>(),
                                           It.IsAny<int?>(),
                                           It.IsAny<string?>(),
+                                          It.IsAny<string?>(),
                                           It.IsAny<string?>()
                                          ), Times.Once);
     }
@@ -95,7 +96,7 @@ public class QualificationSearchServiceTests
     [TestMethod]
     public async Task GetFilteredQualifications_GetsDetails_From_CookieService()
     {
-        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
                        .ReturnsAsync([]);
         var sut = GetSut();
         await sut.GetFilteredQualifications();
@@ -129,7 +130,8 @@ public class QualificationSearchServiceTests
                                           startDateMonth,
                                           startDateYear,
                                           awardingOrganisation,
-                                          qualificationName
+                                          qualificationName,
+                                          null
                                          ), Times.Once);
     }
     
@@ -152,7 +154,8 @@ public class QualificationSearchServiceTests
                                          startDateMonth,
                                          startDateYear,
                                          null,
-                                         qualificationName
+                                         qualificationName,
+                                         null
                                         )).ReturnsAsync([new Qualification("123", qualificationName, "Wrong awarding organisation", 3),
                                                             new Qualification("456", qualificationName, AwardingOrganisations.Various, 3),
                                                             new Qualification("789", qualificationName, AwardingOrganisations.AllHigherEducation, 3)]);
@@ -410,7 +413,7 @@ public class QualificationSearchServiceTests
                              };
 
         _mockUserJourneyCookieService.Setup(o => o.GetAwardingOrganisation()).Returns((string?)null);
-        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
                        .ReturnsAsync(qualifications);
 
         var sut = GetSut();
@@ -431,7 +434,7 @@ public class QualificationSearchServiceTests
                              };
 
         _mockUserJourneyCookieService.Setup(o => o.GetAwardingOrganisation()).Returns((string?)null);
-        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
                        .ReturnsAsync(qualifications);
 
         var sut = GetSut();
@@ -452,7 +455,7 @@ public class QualificationSearchServiceTests
                              };
 
         _mockUserJourneyCookieService.Setup(o => o.GetAwardingOrganisation()).Returns("Pearson Education Ltd");
-        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
                        .ReturnsAsync(qualifications);
 
         var sut = GetSut();
@@ -472,7 +475,7 @@ public class QualificationSearchServiceTests
                              };
 
         _mockUserJourneyCookieService.Setup(o => o.GetAwardingOrganisation()).Returns((string?)null);
-        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
                        .ReturnsAsync(qualifications);
 
         var sut = GetSut();
@@ -488,13 +491,13 @@ public class QualificationSearchServiceTests
         var qualifications = new List<Qualification>();
 
         _mockUserJourneyCookieService.Setup(o => o.GetAwardingOrganisation()).Returns("some org");
-        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), overrideSearch))
+        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), overrideSearch, It.IsAny<string?>()))
                        .ReturnsAsync(qualifications);
 
         var sut = GetSut();
         await sut.GetFilteredQualifications(overrideSearch);
 
-        _mockRepository.Verify(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), overrideSearch), Times.Once);
+        _mockRepository.Verify(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), overrideSearch, It.IsAny<string?>()), Times.Once);
         _mockUserJourneyCookieService.Verify(o => o.GetSearchCriteria(), Times.Never);
     }
 
@@ -506,12 +509,12 @@ public class QualificationSearchServiceTests
 
         _mockUserJourneyCookieService.Setup(o => o.GetAwardingOrganisation()).Returns("some org");
         _mockUserJourneyCookieService.Setup(o => o.GetSearchCriteria()).Returns(cookieSearch);
-        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), cookieSearch))
+        _mockRepository.Setup(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), cookieSearch, It.IsAny<string?>()))
                        .ReturnsAsync(qualifications);
 
         var sut = GetSut();
         await sut.GetFilteredQualifications();
 
-        _mockRepository.Verify(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), cookieSearch), Times.Once);
+        _mockRepository.Verify(o => o.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string?>(), cookieSearch, It.IsAny<string?>()), Times.Once);
     }
 }

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/QualificationsRepositoryTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/QualificationsRepositoryTests.cs
@@ -172,7 +172,7 @@ public class QualificationsRepositoryTests : ContentfulContentServiceTestsBase<Q
         var service =
             new QualificationsRepository(Logger.Object, ClientMock.Object, new Mock<IQualificationListFilter>().Object);
 
-        var result = await service.Get(null, null, null, null, null);
+        var result = await service.Get(null, null, null, null, null, null);
 
         Logger.VerifyWarning("No ratio requirements returned");
 
@@ -208,13 +208,14 @@ public class QualificationsRepositoryTests : ContentfulContentServiceTestsBase<Q
         mockQualificationFilterFactory.Setup(x => x.ApplyFilters(It.IsAny<List<Qualification>>(), It.IsAny<int?>(),
                                                                  It.IsAny<int?>(), It.IsAny<int?>(),
                                                                  It.IsAny<string?>(),
+                                                                 It.IsAny<string?>(),
                                                                  It.IsAny<string?>()))
                                       .Returns([qualification]);
 
         var service =
             new QualificationsRepository(Logger.Object, ClientMock.Object, mockQualificationFilterFactory.Object);
 
-        var result = await service.Get(null, null, null, null, null);
+        var result = await service.Get(null, null, null, null, null, null);
 
         result.Should().HaveCount(1).And.Contain(qualification);
     }
@@ -238,7 +239,7 @@ public class QualificationsRepositoryTests : ContentfulContentServiceTestsBase<Q
         var service =
             new QualificationsRepository(Logger.Object, ClientMock.Object, new Mock<IQualificationListFilter>().Object);
 
-        var result = await service.Get(null, null, null, null, null);
+        var result = await service.Get(null, null, null, null, null, null);
 
         result.Should().BeEmpty();
     }
@@ -257,7 +258,7 @@ public class QualificationsRepositoryTests : ContentfulContentServiceTestsBase<Q
             new QualificationsRepository(mockLogger.Object, mockContentfulClient.Object,
                                          new Mock<IQualificationListFilter>().Object);
 
-        var filteredQualifications = await repository.Get(4, 5, 2016, null, null);
+        var filteredQualifications = await repository.Get(4, 5, 2016, null, null, null);
 
         filteredQualifications.Should().NotBeNull();
         filteredQualifications.Should().BeEmpty();

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/QuestionServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/QuestionServiceTests.cs
@@ -314,7 +314,7 @@ public class QuestionServiceTests
         _ = await GetSut().GetFilteredQualifications();
 
         // Assert
-        _mockQualificationsRepository.Verify(x => x.Get(3, 3, 2002, null, null), Times.Once);
+        _mockQualificationsRepository.Verify(x => x.Get(3, 3, 2002, null, null, null), Times.Once);
     }
 
     [TestMethod]

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Services/WebView/WebViewServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Services/WebView/WebViewServiceTests.cs
@@ -92,7 +92,7 @@ public class WebViewServiceTests
         var expectedModel = new EarlyYearsQualificationListModel();
 
         mockUserJourneyCookieService.Setup(x => x.GetWebViewFilters()).Returns(filters);
-        mockQualificationsRepository.Setup(x => x.Get(3, null, null, null, "Qualification"))
+        mockQualificationsRepository.Setup(x => x.Get(3, null, null, null, "Qualification", null))
             .ReturnsAsync(qualifications);
         mockWebViewPageMapper.Setup(x => x.Map(content, filters, It.IsAny<List<Qualification>>()))
             .ReturnsAsync(expectedModel);
@@ -109,7 +109,7 @@ public class WebViewServiceTests
         // Assert
         result.Should().Be(expectedModel);
         mockUserJourneyCookieService.Verify(x => x.GetWebViewFilters(), Times.Once);
-        mockQualificationsRepository.Verify(x => x.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        mockQualificationsRepository.Verify(x => x.Get(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         mockWebViewPageMapper.Verify(x => x.Map(content, filters, It.IsAny<List<Qualification>>()), Times.Once);
     }
 
@@ -134,7 +134,7 @@ public class WebViewServiceTests
             new("Q1", "Qualification 1", "Org 1", 3)
         };
 
-        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null))
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, null))
             .ReturnsAsync(qualifications);
 
         var service = new WebViewService(
@@ -149,7 +149,7 @@ public class WebViewServiceTests
         // Assert
         result.Should().HaveCount(1);
         result[0].Should().Be(qualifications[0]);
-        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null), Times.Once);
+        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null, null), Times.Once);
     }
 
     [TestMethod]
@@ -173,7 +173,7 @@ public class WebViewServiceTests
             new("Q1", "Qualification 1", "Org 1", 3)
         };
 
-        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null))
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, null))
             .ReturnsAsync(qualifications);
 
         var service = new WebViewService(
@@ -187,7 +187,7 @@ public class WebViewServiceTests
 
         // Assert
         result.Should().HaveCount(1);
-        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null), Times.Once);
+        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null, null), Times.Once);
     }
 
     [TestMethod]
@@ -211,7 +211,7 @@ public class WebViewServiceTests
             new("Q1", "Qualification 1", "Org 1", 3)
         };
 
-        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, "test search"))
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, "test search", null))
             .ReturnsAsync(qualifications);
 
         var service = new WebViewService(
@@ -225,7 +225,7 @@ public class WebViewServiceTests
 
         // Assert
         result.Should().HaveCount(1);
-        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, "test search"), Times.Once);
+        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, "test search", null), Times.Once);
     }
 
     [TestMethod]
@@ -249,7 +249,7 @@ public class WebViewServiceTests
             new("Q1", "Qualification 1", "Org 1", 5)
         };
 
-        mockQualificationsRepository.Setup(x => x.Get(5, null, null, null, null))
+        mockQualificationsRepository.Setup(x => x.Get(5, null, null, null, null, null))
             .ReturnsAsync(qualifications);
 
         var service = new WebViewService(
@@ -263,7 +263,7 @@ public class WebViewServiceTests
 
         // Assert
         result.Should().HaveCount(1);
-        mockQualificationsRepository.Verify(x => x.Get(5, null, null, null, null), Times.Once);
+        mockQualificationsRepository.Verify(x => x.Get(5, null, null, null, null, null), Times.Once);
     }
 
     [TestMethod]
@@ -287,7 +287,7 @@ public class WebViewServiceTests
             new("Q1", "Qualification 1", "Org 1", 3)
         };
 
-        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null))
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, null))
             .ReturnsAsync(qualifications);
 
         var service = new WebViewService(
@@ -301,7 +301,86 @@ public class WebViewServiceTests
 
         // Assert
         result.Should().HaveCount(1);
-        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null), Times.Once);
+        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null, null), Times.Once);
+
+    }
+
+    [TestMethod]
+    public async Task GetQualifications_WithValidNation_PassesNationToRepository()
+    {
+        // Arrange
+        var mockContentService = new Mock<IContentService>();
+        var mockWebViewPageMapper = new Mock<IWebViewPageMapper>();
+        var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
+        var mockQualificationsRepository = new Mock<IQualificationsRepository>();
+
+        var filters = new WebViewFilters
+        {
+            SearchTerm = string.Empty,
+            QualificationLevel = string.Empty,
+            QualificationStartDate = string.Empty,
+            Nation = "Northern-Ireland"
+        };
+
+        var qualifications = new List<Qualification>
+        {
+            new("Q1", "Qualification 1", "Org 1", 3)
+        };
+
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, "Northern-Ireland"))
+            .ReturnsAsync(qualifications);
+
+        var service = new WebViewService(
+            mockContentService.Object,
+            mockWebViewPageMapper.Object,
+            mockUserJourneyCookieService.Object,
+            mockQualificationsRepository.Object);
+
+        // Act
+        var result = await service.GetQualifications(filters);
+
+        // Assert
+        result.Should().HaveCount(1);
+        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null, "Northern-Ireland"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task GetQualifications_WithWhitespaceNation_PassesNullNationToRepository()
+    {
+        // Arrange
+        var mockContentService = new Mock<IContentService>();
+        var mockWebViewPageMapper = new Mock<IWebViewPageMapper>();
+        var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
+        var mockQualificationsRepository = new Mock<IQualificationsRepository>();
+
+        var filters = new WebViewFilters
+        {
+            SearchTerm = string.Empty,
+            QualificationLevel = string.Empty,
+            QualificationStartDate = string.Empty,
+            Nation = "   "
+        };
+
+        var qualifications = new List<Qualification>
+        {
+            new("Q1", "Qualification 1", "Org 1", 3)
+        };
+
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, null))
+            .ReturnsAsync(qualifications);
+
+        var service = new WebViewService(
+            mockContentService.Object,
+            mockWebViewPageMapper.Object,
+            mockUserJourneyCookieService.Object,
+            mockQualificationsRepository.Object);
+
+        // Act
+        var result = await service.GetQualifications(filters);
+
+        // Assert
+        result.Should().HaveCount(1);
+        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null, null), Times.Once);
     }
 
     [TestMethod]
@@ -345,7 +424,7 @@ public class WebViewServiceTests
             }
         };
 
-        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null))
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, null))
             .ReturnsAsync(qualifications);
 
         var service = new WebViewService(
@@ -386,7 +465,7 @@ public class WebViewServiceTests
             new("Q2", "Qualification 2", "Org 2", 3)
         };
 
-        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null))
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, null))
             .ReturnsAsync(qualifications);
 
         var service = new WebViewService(
@@ -426,7 +505,7 @@ public class WebViewServiceTests
             new("Q4", "A Qualification", "Org 4", 3)
         };
 
-        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null))
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, null))
             .ReturnsAsync(qualifications);
 
         var service = new WebViewService(
@@ -459,7 +538,8 @@ public class WebViewServiceTests
         {
             SearchTerm = "old",
             QualificationLevel = "2",
-            QualificationStartDate = "Pre-September 2014"
+            QualificationStartDate = "Pre-September 2014",
+            Nation = "Wales"
         };
 
         mockUserJourneyCookieService.Setup(x => x.GetWebViewFilters()).Returns(existingFilters);
@@ -468,7 +548,8 @@ public class WebViewServiceTests
         {
             SearchTermFilter = "new search",
             QualificationStartDateFilter = "Post-September 2014",
-            QualificationLevelFilter = "3"
+            QualificationLevelFilter = "3",
+            NationFilter = "Northern-Ireland"
         };
 
         var service = new WebViewService(
@@ -484,6 +565,7 @@ public class WebViewServiceTests
         existingFilters.SearchTerm.Should().Be("new search");
         existingFilters.QualificationStartDate.Should().Be("Post-September 2014");
         existingFilters.QualificationLevel.Should().Be("3");
+        existingFilters.Nation.Should().Be("Northern-Ireland");
         mockUserJourneyCookieService.Verify(x => x.GetWebViewFilters(), Times.Once);
         mockUserJourneyCookieService.Verify(x => x.SetWebViewFilters(existingFilters), Times.Once);
     }
@@ -501,7 +583,8 @@ public class WebViewServiceTests
         {
             SearchTerm = "test",
             QualificationLevel = "3",
-            QualificationStartDate = "Pre-September 2014"
+            QualificationStartDate = "Pre-September 2014",
+            Nation = "Wales"
         };
 
         mockUserJourneyCookieService.Setup(x => x.GetWebViewFilters()).Returns(filters);
@@ -519,6 +602,7 @@ public class WebViewServiceTests
         filters.QualificationLevel.Should().BeEmpty();
         filters.SearchTerm.Should().Be("test");
         filters.QualificationStartDate.Should().Be("Pre-September 2014");
+        filters.Nation.Should().Be("Wales");
         mockUserJourneyCookieService.Verify(x => x.SetWebViewFilters(filters), Times.Once);
     }
 
@@ -535,7 +619,8 @@ public class WebViewServiceTests
         {
             SearchTerm = "test",
             QualificationLevel = "3",
-            QualificationStartDate = "Post-September 2014"
+            QualificationStartDate = "Post-September 2014",
+            Nation = "Scotland"
         };
 
         mockUserJourneyCookieService.Setup(x => x.GetWebViewFilters()).Returns(filters);
@@ -553,6 +638,7 @@ public class WebViewServiceTests
         filters.QualificationStartDate.Should().BeEmpty();
         filters.SearchTerm.Should().Be("test");
         filters.QualificationLevel.Should().Be("3");
+        filters.Nation.Should().Be("Scotland");
         mockUserJourneyCookieService.Verify(x => x.SetWebViewFilters(filters), Times.Once);
     }
 
@@ -569,7 +655,8 @@ public class WebViewServiceTests
         {
             SearchTerm = "test",
             QualificationLevel = "3",
-            QualificationStartDate = "Post-September 2014"
+            QualificationStartDate = "Post-September 2014",
+            Nation = "England"
         };
 
         mockUserJourneyCookieService.Setup(x => x.GetWebViewFilters()).Returns(filters);
@@ -585,6 +672,43 @@ public class WebViewServiceTests
 
         // Assert
         filters.SearchTerm.Should().BeEmpty();
+        filters.QualificationLevel.Should().Be("3");
+        filters.QualificationStartDate.Should().Be("Post-September 2014");
+        filters.Nation.Should().Be("England");
+        mockUserJourneyCookieService.Verify(x => x.SetWebViewFilters(filters), Times.Once);
+    }
+
+    [TestMethod]
+    public void RemoveFilter_RemovesNation_WhenFilterContainsNation()
+    {
+        // Arrange
+        var mockContentService = new Mock<IContentService>();
+        var mockWebViewPageMapper = new Mock<IWebViewPageMapper>();
+        var mockUserJourneyCookieService = new Mock<IUserJourneyCookieService>();
+        var mockQualificationsRepository = new Mock<IQualificationsRepository>();
+
+        var filters = new WebViewFilters
+        {
+            SearchTerm = "test",
+            QualificationLevel = "3",
+            QualificationStartDate = "Post-September 2014",
+            Nation = "Northern-Ireland"
+        };
+
+        mockUserJourneyCookieService.Setup(x => x.GetWebViewFilters()).Returns(filters);
+
+        var service = new WebViewService(
+            mockContentService.Object,
+            mockWebViewPageMapper.Object,
+            mockUserJourneyCookieService.Object,
+            mockQualificationsRepository.Object);
+
+        // Act
+        service.RemoveFilter("nation");
+
+        // Assert
+        filters.Nation.Should().BeEmpty();
+        filters.SearchTerm.Should().Be("test");
         filters.QualificationLevel.Should().Be("3");
         filters.QualificationStartDate.Should().Be("Post-September 2014");
         mockUserJourneyCookieService.Verify(x => x.SetWebViewFilters(filters), Times.Once);
@@ -603,7 +727,8 @@ public class WebViewServiceTests
         {
             SearchTerm = "test",
             QualificationLevel = "3",
-            QualificationStartDate = "Post-September 2014"
+            QualificationStartDate = "Post-September 2014",
+            Nation = "Wales"
         };
 
         mockUserJourneyCookieService.Setup(x => x.GetWebViewFilters()).Returns(filters);
@@ -621,6 +746,7 @@ public class WebViewServiceTests
         filters.QualificationLevel.Should().BeEmpty();
         filters.QualificationStartDate.Should().BeEmpty();
         filters.SearchTerm.Should().Be("test");
+        filters.Nation.Should().Be("Wales");
         mockUserJourneyCookieService.Verify(x => x.SetWebViewFilters(filters), Times.Once);
     }
 
@@ -637,7 +763,8 @@ public class WebViewServiceTests
         {
             SearchTerm = "test",
             QualificationLevel = "3",
-            QualificationStartDate = "Post-September 2014"
+            QualificationStartDate = "Post-September 2014",
+            Nation = "Scotland"
         };
 
         mockUserJourneyCookieService.Setup(x => x.GetWebViewFilters()).Returns(filters);
@@ -655,6 +782,7 @@ public class WebViewServiceTests
         filters.SearchTerm.Should().Be("test");
         filters.QualificationLevel.Should().Be("3");
         filters.QualificationStartDate.Should().Be("Post-September 2014");
+        filters.Nation.Should().Be("Scotland");
         mockUserJourneyCookieService.Verify(x => x.SetWebViewFilters(filters), Times.Once);
     }
 
@@ -690,7 +818,7 @@ public class WebViewServiceTests
             }
         };
 
-        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null))
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, null))
             .ReturnsAsync(qualifications);
 
         var service = new WebViewService(
@@ -730,7 +858,7 @@ public class WebViewServiceTests
         var expectedModel = new EarlyYearsQualificationListModel();
 
         mockUserJourneyCookieService.Setup(x => x.GetWebViewFilters()).Returns(filters);
-        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null))
+        mockQualificationsRepository.Setup(x => x.Get(null, null, null, null, null, null))
             .ReturnsAsync(qualifications);
         mockWebViewPageMapper.Setup(x => x.Map(content, filters, It.IsAny<List<Qualification>>()))
             .ReturnsAsync(expectedModel);
@@ -747,7 +875,7 @@ public class WebViewServiceTests
         // Assert
         result.Should().Be(expectedModel);
         mockUserJourneyCookieService.Verify(x => x.GetWebViewFilters(), Times.Once);
-        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null), Times.Once);
+        mockQualificationsRepository.Verify(x => x.Get(null, null, null, null, null, null), Times.Once);
     }
 
     [TestMethod]


### PR DESCRIPTION
# Description

Added field within the WebView, allowing them to select the nation where their qualification was awarded. Users can choose only one of the following options at a time: England, Scotland, Wales, or Northern Ireland.

## Ticket number (if applicable)

https://dfedigital.atlassian.net.mcas.ms/browse/EYQB-1677

# How Has This Been Tested?

Manual, e2e and unit

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules