### PR TITLE
EYQB-1678 added scottish link to webview

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,7 +40,7 @@ jobs:
                 ref: ${{ github.ref }}
 
             - name: GitHub Container Registry Login
-              uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+              uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
               with:
                 registry: ${{ env.GITHUB_CONTAINER_REGISTRY }}
                 username: ${{ github.repository_owner }}
@@ -54,7 +54,7 @@ jobs:
                 echo FORMATTED_BRANCH_NAME="${branchName//\//-}" >> $GITHUB_ENV
 
             - name: Build Image & Publish To GCR
-              uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
               with:
                 context: ./
                 file: ./src/Dfe.EarlyYearsQualification.Web/Dockerfile

--- a/src/Dfe.EarlyYearsQualification.Content/Entities/WebViewPage.cs
+++ b/src/Dfe.EarlyYearsQualification.Content/Entities/WebViewPage.cs
@@ -59,4 +59,6 @@ public class WebViewPage
     public string MultipleQualificationsFoundText { get; init; } = string.Empty;
 
     public string SingleQualificationFoundText { get; init; } = string.Empty;
+
+    public Document QualificationLevelPostHeaderContent { get; init; } = new Document();
 }

--- a/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
+++ b/src/Dfe.EarlyYearsQualification.Mock/Content/MockContentfulService.cs
@@ -1206,7 +1206,16 @@ public class MockContentfulService : IContentService
                 PostHeadingContent = ContentfulContentHelper.Paragraph("This list shows all the qualifications that are approved by the Department for Education as full and relevant."),
                 QualificationIsFullAndRelevantContent = ContentfulContentHelper.Paragraph("Check if an early years qualification is approved as full and relevant"),
                 SingleQualificationFoundText = "qualification found",
-                MultipleQualificationsFoundText = "qualifications found"
+                MultipleQualificationsFoundText = "qualifications found",
+                QualificationLevelPostHeaderContent =
+                new Document
+                {
+                    Content =
+                          [
+                              ContentfulContentHelper.ParagraphWithEmbeddedLink("", "Check English equivalents of Scottish levels",
+                                                                                "/advice/scottish-qualification-levels")
+                          ]
+                }
             }
         );
     }

--- a/src/Dfe.EarlyYearsQualification.Web/Mappers/WebViewMapper.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Mappers/WebViewMapper.cs
@@ -31,6 +31,7 @@ public class WebViewMapper(IGovUkContentParser contentParser) : IWebViewPageMapp
             SearchTermFilter = webViewFilters.SearchTerm,
             NoQualificationsFoundContent = await contentParser.ToHtml(content.NoQualificationsFoundContent),
             CheckIfAnEarlyYearsQualificationIsFullAndRelevantContent = await contentParser.ToHtml(content.QualificationIsFullAndRelevantContent),
+            QualificationLevelPostHeaderContent = await contentParser.ToHtml(content.QualificationLevelPostHeaderContent),
             ApplyFiltersButtonContent = content.ApplyFiltersButtonContent,
             ClearFiltersLinkLabel = content.ClearFiltersLinkLabel,
             FilterHeading = content.FilterHeading,

--- a/src/Dfe.EarlyYearsQualification.Web/Models/Content/EarlyYearsQualificationListModel.cs
+++ b/src/Dfe.EarlyYearsQualification.Web/Models/Content/EarlyYearsQualificationListModel.cs
@@ -42,6 +42,8 @@ public class EarlyYearsQualificationListModel
 
     public string SingleQualificationFoundText { get; init; } = string.Empty;
 
+    public string QualificationLevelPostHeaderContent { get; init; } = string.Empty;
+
     // Filters content
     public string FilterHeading { get; init; } = string.Empty;
 

--- a/src/Dfe.EarlyYearsQualification.Web/Views/QualificationList/Index.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/QualificationList/Index.cshtml
@@ -113,7 +113,7 @@
                     <div class="filter__filter-body__section">
                         <govuk-radios for="QualificationLevelFilter">
                             <govuk-radios-fieldset class="govuk-radios govuk-radios--small">
-                                <govuk-radios-fieldset-legend is-page-heading="false" class="govuk-fieldset__legend--m remove-p-margin">
+                                <govuk-radios-fieldset-legend is-page-heading="false" class="govuk-fieldset__legend--m post-legend-content">
                                     <div>
                                         @Model.QualificationLevelHeading
                                     </div>

--- a/src/Dfe.EarlyYearsQualification.Web/Views/QualificationList/Index.cshtml
+++ b/src/Dfe.EarlyYearsQualification.Web/Views/QualificationList/Index.cshtml
@@ -113,8 +113,11 @@
                     <div class="filter__filter-body__section">
                         <govuk-radios for="QualificationLevelFilter">
                             <govuk-radios-fieldset class="govuk-radios govuk-radios--small">
-                                <govuk-radios-fieldset-legend is-page-heading="false" class="govuk-fieldset__legend--m">
-                                    @Model.QualificationLevelHeading
+                                <govuk-radios-fieldset-legend is-page-heading="false" class="govuk-fieldset__legend--m remove-p-margin">
+                                    <div>
+                                        @Model.QualificationLevelHeading
+                                    </div>
+                                    @Html.Raw(Model.QualificationLevelPostHeaderContent)
                                 </govuk-radios-fieldset-legend>
                                 @foreach (var radio in Model.LevelFilters)
                                 {

--- a/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
+++ b/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
@@ -629,6 +629,6 @@ ol.govuk-list.govuk-list--number ol.govuk-list.govuk-list--number {
     margin-left: 8px;
 }
 
-legend.remove-p-margin > p {
-    margin: 0;
+legend.post-legend-content > p {
+    margin: 10px 0 0 0;
 }

--- a/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
+++ b/src/Dfe.EarlyYearsQualification.Web/wwwroot/css/site.css
@@ -628,3 +628,7 @@ ol.govuk-list.govuk-list--number ol.govuk-list.govuk-list--number {
     font-size: 20px;
     margin-left: 8px;
 }
+
+legend.remove-p-margin > p {
+    margin: 0;
+}

--- a/tests/Dfe.EarlyYearsQualification.AccessibilityTests/.pa11yci-ubuntu.js
+++ b/tests/Dfe.EarlyYearsQualification.AccessibilityTests/.pa11yci-ubuntu.js
@@ -159,6 +159,10 @@ function getUrls(authSecret, port) {
             actions: basicActions.concat(`navigate to http://localhost:${port}/advice/nursing-qualifications`)
         },
         {
+            url: `http://localhost:${port}/advice/scottish-qualification-levels`,
+            actions: basicActions.concat(`navigate to http://localhost:${port}/advice/scottish-qualification-levels`)
+        },
+        {
             url: `http://localhost:${port}/help/I-need-a-copy-of-the-qualification-certificate-or-transcript`,
             actions: basicActions.concat(`navigate to http://localhost:${port}/help/I-need-a-copy-of-the-qualification-certificate-or-transcript`)
         },

--- a/tests/Dfe.EarlyYearsQualification.E2ETests/tests/e2e/pages/webview.spec.ts
+++ b/tests/Dfe.EarlyYearsQualification.E2ETests/tests/e2e/pages/webview.spec.ts
@@ -30,7 +30,8 @@ test.describe("A spec that tests the webview page", {tag: "@e2e"}, () => {
         await checkText(page, "input[value='Pre-September 2014'] ~ label", "Before September 2014");
         await checkText(page, "input[value='Post-September 2014'] ~ label","On or after September 2014");
         await checkText(page, "input[value='Post-September 2024'] ~ label", "On or after September 2024");
-        await checkText(page, "#apply-filter-form div:nth-child(3) legend", "Qualification level");
+        await checkText(page, "#apply-filter-form div:nth-child(3) legend > div", "Qualification level");
+        await checkText(page, "#apply-filter-form div:nth-child(3) legend > p > a", "Check English equivalents of Scottish levels");
         await checkText(page, "input[value='2'] ~ label", "Level 2");
         await checkText(page, "input[value='3'] ~ label", "Level 3");
         await checkText(page, "input[value='4'] ~ label", "Level 4");

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
@@ -1458,10 +1458,10 @@ public class MockContentfulServiceTests
             new Document
             {
                 Content =
-                              [
-                                  ContentfulContentHelper.ParagraphWithEmbeddedLink("", "Check English equivalents of Scottish levels",
-                                                                                    "/advice/scottish-qualification-levels")
-                              ]
+                [
+                    ContentfulContentHelper.ParagraphWithEmbeddedLink("", "Check English equivalents of Scottish levels",
+                                                                    "/advice/scottish-qualification-levels")
+                ]
             }
         );
 

--- a/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
+++ b/tests/Dfe.EarlyYearsQualification.UnitTests/Mocks/MockContentfulServiceTests.cs
@@ -1453,6 +1453,18 @@ public class MockContentfulServiceTests
         result.NoQualificationsFoundContent.Should().BeEquivalentTo(ContentfulContentHelper.Paragraph("No qualifications match the filters you selected."));
         result.PostHeadingContent.Should().BeEquivalentTo(ContentfulContentHelper.Paragraph("This list shows all the qualifications that are approved by the Department for Education as full and relevant."));
         result.QualificationIsFullAndRelevantContent.Should().BeEquivalentTo(ContentfulContentHelper.Paragraph("Check if an early years qualification is approved as full and relevant"));
+
+        result.QualificationIsFullAndRelevantContent.Should().BeEquivalentTo(
+            new Document
+            {
+                Content =
+                              [
+                                  ContentfulContentHelper.ParagraphWithEmbeddedLink("", "Check English equivalents of Scottish levels",
+                                                                                    "/advice/scottish-qualification-levels")
+                              ]
+            }
+        );
+
         result.SingleQualificationFoundText.Should().Be("qualification found");
         result.MultipleQualificationsFoundText.Should().Be("qualifications found");
     }


### PR DESCRIPTION
# Description

A new “Check English equivalent of Scottish level” link is added to the website right under Qualification level as a hyperlink, as specified in the wireframe. When the user clicks the link, it opens on the same browser tab, allowing them to view the relevant information. 

Package updates:
https://github.com/DFE-Digital/check-an-early-years-qualification/pull/978
https://github.com/DFE-Digital/check-an-early-years-qualification/pull/977

## Ticket number (if applicable)

https://dfedigital.atlassian.net.mcas.ms/browse/EYQB-1678

# How Has This Been Tested?

Manual, e2e unit

# Screenshots

Please include screenshots if applicable.

# Checklist:

- [x] My code follows the standards used within this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests (Unit, E2E) that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules